### PR TITLE
Apply WordPress filter to all configs

### DIFF
--- a/src/Acorn/Config.php
+++ b/src/Acorn/Config.php
@@ -6,5 +6,20 @@ use Illuminate\Config\Repository as ConfigBase;
 
 class Config extends ConfigBase
 {
-    // this class is intentionally blank
+    /**
+     * Set a given configuration value.
+     *
+     * @param  array|string  $key
+     * @param  mixed   $value
+     * @return void
+     */
+    public function set($key, $value = null)
+    {
+        $keys = is_array($key) ? $key : [$key => $value];
+
+        foreach ($keys as $key => $value) {
+            $value = apply_filters("roots.acorn.config.{$key}", $value);
+            Arr::set($this->items, $key, $value);
+        }
+    }
 }


### PR DESCRIPTION
Feel free to thumbs up/down this idea.

Pros
- provides a more accessible api for acorn newcomers
- crude method to ensure a particular config value is applied

Cons
- misuse of the filter (esp. by third parties) could result in difficult bugs to squash
