### PR TITLE
Make Acorn work with Mix's manifest

### DIFF
--- a/src/Acorn/Application.php
+++ b/src/Acorn/Application.php
@@ -130,6 +130,20 @@ class Application extends Container implements ApplicationContract
     }
 
     /**
+     * Register all of the configured providers.
+     *
+     * @return void
+     */
+    public function registerConfiguredProviders()
+    {
+        collect($this['config']['app']['providers'])->each(
+            function (string $provider) {
+                $this->register($provider);
+            }
+        );
+    }
+
+    /**
      * Register the core class aliases in the container.
      *
      * @return void

--- a/src/Acorn/Assets/Asset.php
+++ b/src/Acorn/Assets/Asset.php
@@ -3,6 +3,7 @@
 namespace Roots\Acorn\Assets;
 
 use Roots\Acorn\Contracts\Assets\Asset as AssetContract;
+use Illuminate\Support\Str;
 
 class Asset implements AssetContract
 {
@@ -50,13 +51,13 @@ class Asset implements AssetContract
     /**
      * Get the asset's cache-busted relative path
      *
-     * Example: styles/a1b2c3.min.css
+     * Example: /styles/a1b2c3.min.css
      *
      * @return string
      */
     public function revved()
     {
-        return ($this->manifest[$this->path] ?? $this->original());
+        return Str::start($this->manifest[Str::start($this->path, '/')] ?? $this->original(), '/');
     }
 
     /**
@@ -68,7 +69,7 @@ class Asset implements AssetContract
      */
     public function uri()
     {
-        return "{$this->manifest->uri()}/{$this->revved()}";
+        return $this->manifest->uri() . $this->revved();
     }
 
     /**
@@ -80,7 +81,7 @@ class Asset implements AssetContract
      */
     public function path()
     {
-        return "{$this->manifest->path()}/{$this->revved()}";
+        return Str::before($this->manifest->path() . $this->revved(), '?');
     }
 
     /**

--- a/src/Acorn/Bootstrap/RegisterProviders.php
+++ b/src/Acorn/Bootstrap/RegisterProviders.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Roots\Acorn\Bootstrap;
+
+use Illuminate\Contracts\Foundation\Application;
+
+class RegisterProviders
+{
+    /**
+     * Bootstrap the given application.
+     *
+     * @param  \Roots\Acorn\Application  $app
+     * @return void
+     */
+    public function bootstrap(Application $app)
+    {
+        $app->registerConfiguredProviders();
+    }
+}

--- a/src/Acorn/Clover/ServiceProvider.php
+++ b/src/Acorn/Clover/ServiceProvider.php
@@ -17,7 +17,7 @@ abstract class ServiceProvider extends BaseServiceProvider
      */
     public function register()
     {
-        if (!$configFile = $this->locateConfig()) {
+        if (! $configFile = $this->locateConfig()) {
             return;
         }
 

--- a/src/Acorn/Sage/SageServiceProvider.php
+++ b/src/Acorn/Sage/SageServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Roots\Acorn\Sage;
 
 use function Roots\add_filters;
+
 use Roots\Acorn\Config;
 use Roots\Acorn\Sage\Sage;
 use Roots\Acorn\Sage\ViewFinder;

--- a/src/Acorn/View/ViewServiceProvider.php
+++ b/src/Acorn/View/ViewServiceProvider.php
@@ -90,7 +90,7 @@ class ViewServiceProvider extends ViewServiceProviderBase
         $directives = $this->app['config']['view.directives'];
         $directives += ['inject' => InjectionDirective::class];
         foreach ($directives as $name => $handler) {
-            if (!is_callable($handler)) {
+            if (! is_callable($handler)) {
                 $handler = $this->app->make($handler);
             }
             $blade->directive($name, $handler);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -114,6 +114,7 @@ function bootloader()
         \Roots\Acorn\Bootstrap\SageFeatures::class,
         \Roots\Acorn\Bootstrap\LoadConfiguration::class,
         \Roots\Acorn\Bootstrap\LoadBindings::class,
+        \Roots\Acorn\Bootstrap\RegisterProviders::class,
         \Roots\Acorn\Bootstrap\RegisterGlobals::class,
     ];
     $application_basepath = dirname(locate_template('config') ?: __DIR__);

--- a/tests/Unit/AssetDirectiveTest.php
+++ b/tests/Unit/AssetDirectiveTest.php
@@ -11,7 +11,7 @@ class AssetDirectiveTest extends TestCase
     {
         $directive = new \Roots\Acorn\Assets\AssetDirective();
 
-        $this->assertEquals("<?= \Roots\asset('scripts/main.js'); ?>", $directive("'scripts/main.js'"));
+        $this->assertEquals("<?= \Roots\asset('scripts/app.js'); ?>", $directive("'scripts/app.js'"));
         $this->assertEquals('<?= \Roots\asset($file); ?>', $directive('$file'));
     }
 }

--- a/tests/Unit/AssetTest.php
+++ b/tests/Unit/AssetTest.php
@@ -16,17 +16,17 @@ class AssetTest extends TestCase
     /** @test */
     public function it_should_return_the_original_relative_path()
     {
-        $asset = $this->getAsset('scripts/main.js');
+        $asset = $this->getAsset('scripts/app.js');
 
-        $this->assertEquals('scripts/main.js', $asset->original());
+        $this->assertEquals('scripts/app.js', $asset->original());
     }
 
     /** @test */
     public function it_should_return_the_revved_relative_path()
     {
-        $asset = $this->getAsset('scripts/main.js');
+        $asset = $this->getAsset('scripts/app.js');
 
-        $this->assertEquals('scripts/main-123456.js', $asset->revved());
+        $this->assertEquals('/scripts/app-123456.js', $asset->revved());
     }
 
     /** @test */
@@ -34,33 +34,51 @@ class AssetTest extends TestCase
     {
         $asset = $this->getAsset('scripts/notafile.js');
 
-        $this->assertEquals('scripts/notafile.js', $asset->revved());
+        $this->assertEquals('/scripts/notafile.js', $asset->revved());
     }
 
     /** @test */
     public function it_should_prepend_manifest_uri()
     {
-        $asset = $this->getAsset('scripts/main.js');
+        $asset = $this->getAsset('scripts/app.js');
         $asset2 = $this->getAsset('scripts/notafile.js');
 
-        $this->assertEquals(static::FAKE_URI . '/scripts/main-123456.js', $asset->uri());
+        $this->assertEquals(static::FAKE_URI . '/scripts/app-123456.js', $asset->uri());
+        $this->assertEquals(static::FAKE_URI . '/scripts/notafile.js', $asset2->uri());
+    }
+
+    /** @test */
+    public function it_should_prepend_manifest_uri_with_query_string()
+    {
+        $asset = $this->getAsset('scripts/app.js', ['/scripts/app.js' => '/scripts/app.js?id=123456']);
+        $asset2 = $this->getAsset('scripts/notafile.js');
+
+        $this->assertEquals(static::FAKE_URI . '/scripts/app.js?id=123456', $asset->uri());
         $this->assertEquals(static::FAKE_URI . '/scripts/notafile.js', $asset2->uri());
     }
 
     /** @test */
     public function it_should_prepend_manifest_path()
     {
-        $asset = $this->getAsset('scripts/main.js');
+        $asset = $this->getAsset('scripts/app.js');
         $asset2 = $this->getAsset('scripts/notafile.js');
 
-        $this->assertEquals(static::FAKE_PATH . '/scripts/main-123456.js', $asset->path());
+        $this->assertEquals(static::FAKE_PATH . '/scripts/app-123456.js', $asset->path());
         $this->assertEquals(static::FAKE_PATH . '/scripts/notafile.js', $asset2->path());
+    }
+
+    /** @test */
+    public function it_should_prepend_manifest_path_without_query_string()
+    {
+        $asset = $this->getAsset('scripts/app.js', ['/scripts/app.js' => '/scripts/app.js?id=123456']);
+
+        $this->assertEquals(static::FAKE_PATH . '/scripts/app.js', $asset->path());
     }
 
     /** @test */
     public function it_should_return_uri_when_converted_to_string()
     {
-        $asset = $this->getAsset('scripts/main.js');
+        $asset = $this->getAsset('scripts/app.js');
 
         $this->assertEquals($asset->uri(), (string) $asset);
     }
@@ -68,7 +86,7 @@ class AssetTest extends TestCase
     /** @test */
     public function it_should_return_a_manifest()
     {
-        $asset = $this->getAsset('scripts/main.js');
+        $asset = $this->getAsset('scripts/app.js');
 
         $this->assertInstanceOf(\Roots\Acorn\Assets\Manifest::class, $asset->getManifest());
     }
@@ -81,8 +99,8 @@ class AssetTest extends TestCase
     protected function getAsset($path, $manifest = null)
     {
         $default = [
-            "scripts/main.js" => "scripts/main-123456.js",
-            "styles/main.css" => "styles/main-123456.css",
+            '/scripts/app.js' => '/scripts/app-123456.js',
+            '/styles/app.css' => '/styles/app-123456.css',
         ];
 
         $manifest = new \Roots\Acorn\Assets\Manifest($manifest ?? $default, static::FAKE_URI, static::FAKE_PATH);

--- a/tests/mock-api.php
+++ b/tests/mock-api.php
@@ -4,28 +4,28 @@ define('WP_CONTENT_DIR', 'vfs://__fixtures__/app');
 
 define('ABSPATH', 'vfs://__fixtures__/wp');
 
-if (!function_exists('content_url')) {
+if (! function_exists('content_url')) {
     function content_url()
     {
         return '/app';
     }
 }
 
-if (!function_exists('site_url')) {
+if (! function_exists('site_url')) {
     function site_url()
     {
         return '/wp';
     }
 }
 
-if (!function_exists('get_parent_theme_file_path')) {
+if (! function_exists('get_parent_theme_file_path')) {
     function get_parent_theme_file_path($file = '')
     {
         return get_theme_file_path($file);
     }
 }
 
-if (!function_exists('get_theme_file_path')) {
+if (! function_exists('get_theme_file_path')) {
     function get_theme_file_path($file = '')
     {
         $file = ltrim($file, '/\\');
@@ -33,7 +33,7 @@ if (!function_exists('get_theme_file_path')) {
     }
 }
 
-if (!function_exists('get_theme_file_uri')) {
+if (! function_exists('get_theme_file_uri')) {
     function get_theme_file_uri($file = '')
     {
         $file = ltrim($file, '/\\');
@@ -41,7 +41,7 @@ if (!function_exists('get_theme_file_uri')) {
     }
 }
 
-if (!function_exists('wp_upload_dir')) {
+if (! function_exists('wp_upload_dir')) {
     function wp_upload_dir()
     {
         return [
@@ -54,21 +54,21 @@ if (!function_exists('wp_upload_dir')) {
     }
 }
 
-if (!function_exists('add_filter')) {
+if (! function_exists('add_filter')) {
     function add_filter()
     {
         return null;
     }
 }
 
-if (!function_exists('add_action')) {
+if (! function_exists('add_action')) {
     function add_action()
     {
         return null;
     }
 }
 
-if (!function_exists('did_action')) {
+if (! function_exists('did_action')) {
     function did_action()
     {
         return null;


### PR DESCRIPTION
This adds support for Mix's manifest which requires the path to be prepended with `/`.

When fetching the local path, I made use of `Str::before()` to strip `?id=X` thus making it functional with Mix's built in `.version()` as well as plugins such as [laravel-mix-versionhash](https://github.com/ctf0/laravel-mix-versionhash) which handle hashing via the filename instead of a query string.