### PR TITLE
Load config and register providers

### DIFF
--- a/src/Acorn/Application.php
+++ b/src/Acorn/Application.php
@@ -130,6 +130,20 @@ class Application extends Container implements ApplicationContract
     }
 
     /**
+     * Register all of the configured providers.
+     *
+     * @return void
+     */
+    public function registerConfiguredProviders()
+    {
+        collect($this['config']['app']['providers'])->each(
+            function (string $provider) {
+                $this->register($provider);
+            }
+        );
+    }
+
+    /**
      * Register the core class aliases in the container.
      *
      * @return void

--- a/src/Acorn/Bootstrap/RegisterProviders.php
+++ b/src/Acorn/Bootstrap/RegisterProviders.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Roots\Acorn\Bootstrap;
+
+use Illuminate\Contracts\Foundation\Application;
+
+class RegisterProviders
+{
+    /**
+     * Bootstrap the given application.
+     *
+     * @param  \Roots\Acorn\Application  $app
+     * @return void
+     */
+    public function bootstrap(Application $app)
+    {
+        $app->registerConfiguredProviders();
+    }
+}

--- a/src/Acorn/Sage/SageServiceProvider.php
+++ b/src/Acorn/Sage/SageServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Roots\Acorn\Sage;
 
 use function Roots\add_filters;
+
 use Roots\Acorn\Config;
 use Roots\Acorn\Sage\Sage;
 use Roots\Acorn\Sage\ViewFinder;
@@ -15,9 +16,6 @@ class SageServiceProvider extends ServiceProvider
     {
         $this->app->singleton('sage', Sage::class);
         $this->app->bind('sage.finder', ViewFinder::class);
-
-        $this->loadConfig();
-        $this->registerProviders();
     }
 
     public function boot()
@@ -25,25 +23,5 @@ class SageServiceProvider extends ServiceProvider
         if ($this->app->bound('view')) {
             $this->app['sage']->attach();
         }
-    }
-
-    private function loadConfig()
-    {
-        collect($this->app->configPath('app'))->each(
-            function (string $item) {
-                $this->app->configure(basename($item, '.php'));
-            }
-        );
-    }
-
-    private function registerProviders()
-    {
-        $providers = $this->app['config']['app']['providers'];
-
-        collect($providers)->each(
-            function (string $provider) {
-                $this->app->register($provider);
-            }
-        );
     }
 }

--- a/src/Acorn/Sage/SageServiceProvider.php
+++ b/src/Acorn/Sage/SageServiceProvider.php
@@ -15,6 +15,9 @@ class SageServiceProvider extends ServiceProvider
     {
         $this->app->singleton('sage', Sage::class);
         $this->app->bind('sage.finder', ViewFinder::class);
+
+        $this->loadConfig();
+        $this->registerProviders();
     }
 
     public function boot()
@@ -22,5 +25,25 @@ class SageServiceProvider extends ServiceProvider
         if ($this->app->bound('view')) {
             $this->app['sage']->attach();
         }
+    }
+
+    private function loadConfig()
+    {
+        collect($this->app->configPath('app'))->each(
+            function (string $item) {
+                $this->app->configure(basename($item, '.php'));
+            }
+        );
+    }
+
+    private function registerProviders()
+    {
+        $providers = $this->app['config']['app']['providers'];
+
+        collect($providers)->each(
+            function (string $provider) {
+                $this->app->register($provider);
+            }
+        );
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -114,6 +114,7 @@ function bootloader()
         \Roots\Acorn\Bootstrap\SageFeatures::class,
         \Roots\Acorn\Bootstrap\LoadConfiguration::class,
         \Roots\Acorn\Bootstrap\LoadBindings::class,
+        \Roots\Acorn\Bootstrap\RegisterProviders::class,
         \Roots\Acorn\Bootstrap\RegisterGlobals::class,
     ];
     $application_basepath = dirname(locate_template('config') ?: __DIR__);


### PR DESCRIPTION
Added two private methods to `SageServiceProvider` in order to load the Sage app configuration and register the providers from the `providers` array.

Addresses #14 .