### PR TITLE
[WIP] Check that .blade.php cannot be accessed remotely

### DIFF
--- a/src/Acorn/Sage/SageServiceProvider.php
+++ b/src/Acorn/Sage/SageServiceProvider.php
@@ -24,4 +24,35 @@ class SageServiceProvider extends ServiceProvider
             $this->app['sage']->attach();
         }
     }
+
+    public function preflight(\WP_Http $client)
+    {
+        $response = $client->request(get_theme_file_uri('resources/views/index.blade.php'), [
+            'method' => 'HEAD',
+            'sslverify' => ! $this->app->environment('local', 'testing', 'test', 'dev', 'development'),
+            'sslcertificates' => $this->getCertificate()
+        ]);
+
+        $status_code = wp_remote_retrieve_response_code($response);
+
+        if ($status_code >= 200 && $status_code < 300) {
+            throw new \Exception('i should not b abl 2 c bladez ya dummy');
+        }
+    }
+
+    /**
+     * Get CA bundle from common system locations.
+     *
+     * This follows a similar routine as Guzzle with notable
+     * fallback to CA bundle provided by WordPress.
+     *
+     * @return string Path to certificate
+     */
+    protected function getCertificate() : string
+    {
+        return ini_get('openssl.cafile')
+            ?: ini_get('curl.cainfo')
+            ?: openssl_get_cert_locations()['default_cert_file']
+            ?? \ABSPATH . \WPINC . '/certificates/ca-bundle.crt';
+    }
 }


### PR DESCRIPTION
Should this be cached, or should it be a manual check via wp-cli? Should this throw an error or show a more polite notification/alert? What sort of options/filters should be implemented?

Should we instead put this on the ViewServiceProvider and iterate over all view paths within the document root and select an actual .blade.php from each path to ensure all paths are protected?

Not sure how crazy we want to get with this. I'm personally of the mindset that this is outside the scope of Sage and Acorn, and I'd be in favor of completely removing it. But if we do want it, my preference would be to implement it as a wp-cli command.