### PR TITLE
chore(readme): Use brand color for Twitter follow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Packagist](https://img.shields.io/packagist/vpre/roots/acorn.svg?style=flat-square)](https://packagist.org/packages/roots/acorn)
 [![Build Status](https://img.shields.io/travis/roots/acorn.svg?style=flat-square)](https://travis-ci.org/roots/acorn)
-[![Follow Roots](https://img.shields.io/twitter/follow/rootswp.svg?style=flat-square)](https://twitter.com/rootswp)
+[![Follow Roots](https://img.shields.io/twitter/follow/rootswp.svg?style=flat-square&color=1da1f2)](https://twitter.com/rootswp)
 
 Acorn is a framework for building plugins


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2104321/61225245-0bef7c80-a6d5-11e9-9902-fe3681fa8392.png)

The default gray color is the same color used when there's an error, implying that our 3k followers are an error. That makes me sad.

The color hex comes from [Twitter's brand resources](https://about.twitter.com/en_us/company/brand-resources.html).