### PR TITLE
Add view config option for blade component aliases

### DIFF
--- a/config/view.php
+++ b/config/view.php
@@ -98,4 +98,32 @@ return [
     'directives' => [
         'asset'  => Roots\Acorn\Assets\AssetDirective::class
     ],
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Blade Component Aliases
+    |--------------------------------------------------------------------------
+    |
+    | Component aliases allow you to use a shorthand to call a Blade component.
+    | Instead of referencing your components like this:
+    |
+    | @component('components.alert', ['type' => 'warning'])
+    |   {{ __('Page not found') }}
+    | @endcomponent
+    |
+    | You can use an alias instead:
+    |
+    | @alert(['type' => 'error'])
+    |   {{ __('Page not found') }}
+    | @endalert
+    |
+    | Use the key to set the alias and the value to set the path to the
+    | view.
+    |
+    */
+
+    'components' => [
+        // 'alert'  => 'components.alert',
+    ],
 ];

--- a/src/Acorn/View/ViewServiceProvider.php
+++ b/src/Acorn/View/ViewServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Roots\Acorn\View;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 use Illuminate\View\View;
 use Illuminate\View\ViewServiceProvider as ViewServiceProviderBase;
 use Roots\Acorn\View\Composers\Debugger;
@@ -101,7 +102,7 @@ class ViewServiceProvider extends ViewServiceProviderBase
     {
         $components = $this->app->config['view.components'];
 
-        if (! empty($components)) {
+        if (is_array($components) && Arr::isAssoc($components)) {
             $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
             foreach ($components as $alias => $view) {
                 $blade->component($view, $alias);

--- a/src/Acorn/View/ViewServiceProvider.php
+++ b/src/Acorn/View/ViewServiceProvider.php
@@ -67,6 +67,7 @@ class ViewServiceProvider extends ViewServiceProviderBase
     public function boot()
     {
         $this->attachDirectives();
+        $this->attachComponents();
         $this->attachComposers();
 
         if ($this->app['config']['view.debug']) {
@@ -93,6 +94,18 @@ class ViewServiceProvider extends ViewServiceProviderBase
                 $handler = $this->app->make($handler);
             }
             $blade->directive($name, $handler);
+        }
+    }
+
+    public function attachComponents()
+    {
+        $components = $this->app->config['view.components'];
+
+        if (! empty($components)) {
+            $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
+            foreach ($components as $alias => $view) {
+                $blade->component($view, $alias);
+            }
         }
     }
 


### PR DESCRIPTION
~I haven’t tested this, but logically it checks out.~ It works.

We'd need to PR Sage with the updated config example.