### PR TITLE
Small clean up for Sage

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -16,6 +16,19 @@ return [
     */
 
     'preflight' => false,
+    
+    /*
+    |--------------------------------------------------------------------------
+    | Global Helpers
+    |--------------------------------------------------------------------------
+    |
+    | This value enables the usage of various Acorn helpers without the need
+    | to specify a namespace. This defaults to false as to not pollute the
+    | global namespace.
+    |
+    */
+
+    'globals' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Acorn/Bootstrap/LoadConfiguration.php
+++ b/src/Acorn/Bootstrap/LoadConfiguration.php
@@ -2,10 +2,10 @@
 
 namespace Roots\Acorn\Bootstrap;
 
-use Symfony\Component\Finder\Finder;
-use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Contracts\Config\Repository as RepositoryContract;
 use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository as RepositoryContract;
+use Illuminate\Contracts\Foundation\Application;
+use Symfony\Component\Finder\Finder;
 
 
 class LoadConfiguration
@@ -42,10 +42,6 @@ class LoadConfiguration
         $app->detectEnvironment(function () use ($config) {
             return $config->get('app.env', defined('WP_ENV') ? \WP_ENV : 'production');
         });
-
-        date_default_timezone_set($config->get('app.timezone', 'UTC'));
-
-        mb_internal_encoding('UTF-8');
     }
 
     /**

--- a/src/Acorn/Bootstrap/LoadConfiguration.php
+++ b/src/Acorn/Bootstrap/LoadConfiguration.php
@@ -42,6 +42,10 @@ class LoadConfiguration
         $app->detectEnvironment(function () use ($config) {
             return $config->get('app.env', defined('WP_ENV') ? \WP_ENV : 'production');
         });
+
+        date_default_timezone_set($config->get('app.timezone', 'UTC'));
+
+        mb_internal_encoding('UTF-8');
     }
 
     /**

--- a/src/Acorn/Bootstrap/RegisterGlobals.php
+++ b/src/Acorn/Bootstrap/RegisterGlobals.php
@@ -18,7 +18,7 @@ class RegisterGlobals
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication($app);
 
-        if (! apply_filters('acorn/globals', false)) {
+        if (! $app->config->get('app.globals', false)) {
             return;
         }
 

--- a/src/Acorn/Bootstrap/SageFeatures.php
+++ b/src/Acorn/Bootstrap/SageFeatures.php
@@ -2,7 +2,6 @@
 
 namespace Roots\Acorn\Bootstrap;
 
-use function Roots\add_filters;
 use Illuminate\Contracts\Foundation\Application;
 
 class SageFeatures

--- a/src/Acorn/Console/Commands/Command.php
+++ b/src/Acorn/Console/Commands/Command.php
@@ -2,8 +2,8 @@
 
 namespace Roots\Acorn\Console\Commands;
 
-use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Command as CommandBase;
+use Illuminate\Console\Scheduling\Schedule;
 
 abstract class Command extends CommandBase
 {

--- a/src/Acorn/Sage/Concerns/FiltersBodyClass.php
+++ b/src/Acorn/Sage/Concerns/FiltersBodyClass.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Roots\Acorn\Sage\Concerns;
+
+trait FiltersBodyClass
+{
+    /**
+     * Clean up the body class and append the page slug.
+     *
+     * Filter: body_class
+     *
+     * @param  array $classes
+     * @return array
+     */
+    public function filterBodyClass($classes)
+    {
+        $classes = collect($classes);
+
+        if (is_single() || is_page() && ! is_front_page()) {
+            if (! $classes->containsStrict($class = basename(get_permalink()))) {
+                $classes->push($class);
+            }
+        }
+
+        return $classes->map(function ($class) {
+            return preg_replace(['/-blade(-php)?$/', '/^page-template-views/'], '', $class);
+        })
+        ->filter()
+        ->all();
+    }
+}

--- a/src/Acorn/Sage/Concerns/FiltersTemplates.php
+++ b/src/Acorn/Sage/Concerns/FiltersTemplates.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Roots\Acorn\Sage\Concerns;
+
+trait FiltersTemplates
+{
+    /**
+     * Use compiled Blade view when returning a template.
+     *
+     * Filter: {type}_template_hierarchy
+     *
+     * @param  array $files
+     * @return string[] List of possible views
+     */
+    public function filterTemplateHierarchy($files)
+    {
+        return $this->sageFinder->locate($files);
+    }
+
+    /**
+     * Include compiled Blade view with data attached.
+     *
+     * Filter: template_include
+     *
+     * @param  string
+     * @return string
+     */
+    public function filterTemplateInclude($file)
+    {
+        $view = $this->fileFinder
+            ->getPossibleViewNameFromPath(realpath($file));
+
+        /** Gather data to be passed to view */
+        $data = array_reduce(get_body_class(), function ($data, $class) use ($view, $file) {
+            return apply_filters("sage/template/{$class}/data", $data, $view, $file);
+        }, []);
+
+        $this->app['sage.view'] = $view;
+        $this->app['sage.data'] = $data;
+
+        return get_template_directory() . '/index.php';
+    }
+
+    /**
+     * Add Blade compatability for theme templates.
+     *
+     * NOTE: Internally, WordPress interchangeably uses "page templates" "post templates" and "theme templates"
+     *
+     * Filter: theme_templates
+     *
+     * @return string[] List of theme templates
+     */
+    public function filterThemeTemplates($_templates, $_theme, $_post, $post_type)
+    {
+        $templates = [];
+
+        // TODO: This should be cacheable, perhaps via `wp acorn` command
+        foreach (array_reverse($this->fileFinder->getPaths()) as $path) {
+            /**
+             * We use the exact same technique as WordPress core for detecting template files.
+             *
+             * Caveat: we go infinite levels deep within the views folder.
+             *
+             * @see \WP_Theme::get_post_templates()
+             * @link https://github.com/WordPress/WordPress/blob/5.2.1/wp-includes/class-wp-theme.php#L1146-L1164
+             */
+            foreach ($this->files->glob("{$path}/**.php") as $full_path) {
+                if (! preg_match('|Template Name:(.*)$|mi', file_get_contents($full_path), $header)) {
+                    continue;
+                }
+
+                $types = ['page'];
+
+                if (preg_match('|Template Post Type:(.*)$|mi', file_get_contents($full_path), $type)) {
+                    $types = explode(',', _cleanup_header_comment($type[1]));
+                }
+
+                $file = $this->files->getRelativePath("{$path}/", $full_path);
+
+                foreach ($types as $type) {
+                    $type = sanitize_key($type);
+
+                    if (! isset($templates[$type])) {
+                        $templates[$type] = [];
+                    }
+
+                    $templates[$type][$file] = _cleanup_header_comment($header[1]);
+                }
+            }
+        }
+
+        // NOTE: We collect $_templates, not $templates.
+        return collect($_templates)
+            ->merge($templates[$post_type] ?? [])
+            ->unique()
+            ->toArray();
+    }
+}

--- a/src/Acorn/Sage/Concerns/FiltersThePost.php
+++ b/src/Acorn/Sage/Concerns/FiltersThePost.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Roots\Acorn\Sage\Concerns;
+
+trait FiltersThePost
+{
+    /**
+     * Attach global `$post` variable to Blade views.
+     *
+     * Filter: the_post
+     *
+     * @param  WP_Post $post
+     * @return void
+     */
+    public function filterThePost($post)
+    {
+        $this->view->share('post', $post);
+    }
+}

--- a/src/Acorn/Sage/Concerns/FiltersViews.php
+++ b/src/Acorn/Sage/Concerns/FiltersViews.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Roots\Acorn\Sage\Concerns;
+
+use function Roots\view;
+
+trait FiltersViews
+{
+    /**
+     * Search for a compiled Blade partial when resolving the comments template.
+     *
+     * Filter: comments_template
+     *
+     * @param  string $file
+     * @return string Path to comments template
+     */
+    public function filterCommentsTemplate($file)
+    {
+        if (Str::startsWith($file, [STYLESHEETPATH, TEMPLATEPATH])) {
+            $file = ltrim(str_replace([STYLESHEETPATH, TEMPLATEPATH], '', $file), '\\/');
+        }
+
+        if ($file === 'comments.php') {
+            $file = 'partials/comments.blade.php';
+        }
+
+        return view(
+            $this->fileFinder->getPossibleViewNameFromPath($file)
+        )->makeLoader();
+    }
+
+    /**
+     * Use `forms/search.blade.php` for the search form.
+     *
+     * Filter: get_search_form
+     *
+     * @return string Rendered view
+     */
+    public function filterSearchForm($view)
+    {
+        return view()->exists('forms.search') ? view('forms.search') : $view;
+    }
+}

--- a/src/Acorn/Sage/Sage.php
+++ b/src/Acorn/Sage/Sage.php
@@ -71,7 +71,7 @@ class Sage
      */
     public function attach()
     {
-        $this->attachPostVariable();
+        $this->attachPostFilter();
         $this->attachCommentsTemplateFilter();
         $this->attachSearchFormFilter();
         $this->attachBodyClassFilter();

--- a/src/Acorn/Sage/Sage.php
+++ b/src/Acorn/Sage/Sage.php
@@ -61,7 +61,7 @@ class Sage
         $this->files = $files;
         $this->fileFinder = $fileFinder;
         $this->sageFinder = $sageFinder;
-        $this->views = $view;
+        $this->view = $view;
     }
 
     /**
@@ -72,7 +72,7 @@ class Sage
     public function attach()
     {
         $this->attachPostVariable();
-        $this->attachCommentsTemplateResolver();
+        $this->attachCommentsTemplateFilter();
         $this->attachSearchFormFilter();
         $this->attachBodyClassFilter();
         $this->attachTemplateHierarchyFilters();
@@ -83,75 +83,121 @@ class Sage
     /**
      * Attach global `$post` variable to Blade views.
      *
+     * @param  WP_Post $post
+     * @return void
+     */
+    public function filterPost($post)
+    {
+        $this->view->share('post', $post);
+    }
+
+    /**
+     * Attach the post filter.
+     *
      * @param  integer $priority
      * @return void
      */
-    public function attachPostVariable($priority = 10)
+    protected function attachPostFilter($priority = 10)
     {
-        add_action('the_post', function ($post) {
-            $this->view->share('post', $post);
-        }, $priority);
+        add_action('the_post', [$this, 'filterPost'], $priority);
     }
 
     /**
      * Search for a compiled Blade partial when resolving the comments template.
      *
-     * @param  integer $priority
-     * @return void
+     * @param  string $file
+     * @return string
      */
-    public function attachCommentsTemplateResolver($priority = 100)
+    public function filterCommentsTemplate($file)
     {
-        add_filter('comments_template', function ($name) {
-            if (Str::startsWith($file, [STYLESHEETPATH, TEMPLATEPATH])) {
-                $file = ltrim(str_replace([STYLESHEETPATH, TEMPLATEPATH], '', $file), '\\/');
-            }
+        if (Str::startsWith($file, [STYLESHEETPATH, TEMPLATEPATH])) {
+            $file = ltrim(str_replace([STYLESHEETPATH, TEMPLATEPATH], '', $file), '\\/');
+        }
 
-            if ($file == '/comments.php') {
-                $file = '/partials/comments.blade.php';
-            }
+        if ($file == 'comments.php') {
+            $file = 'partials/comments.blade.php';
+        }
 
-            return view(
-                $this->fileFinder->getPossibleViewNameFromPath($file)
-            )->makeLoader();
-        }, $priority);
+        return view(
+            $this->fileFinder->getPossibleViewNameFromPath($file)
+        )->makeLoader();
     }
 
     /**
-     * Use search.blade.php for the search form.
+     * Attach the comments template filter.
      *
      * @param  integer $priority
      * @return void
      */
-    public function attachSearchFormFilter($priority = 100)
+    protected function attachCommentsTemplateFilter($priority = 100)
     {
-        add_filter('get_search_form', function () {
-            return view('forms.search');
-        }, $priority);
+        add_filter('comments_template', [$this, 'filterCommentsTemplate'], $priority);
+    }
+
+    /**
+     * Use `forms/search.blade.php` for the search form.
+     *
+     * @return string
+     */
+    public function filterSearchForm()
+    {
+        return view('forms.search');
+    }
+
+    /**
+     * Attach the search form filter.
+     *
+     * @param  integer $priority
+     * @return void
+     */
+    protected function attachSearchFormFilter($priority = 100)
+    {
+        add_filter('get_search_form', [$this, 'filterSearchForm'], $priority);
     }
 
     /**
      * Clean up the body class and append the page slug.
      *
+     * @param  array $classes
+     * @return array
+     */
+    public function filterBodyClass($classes)
+    {
+        $classes = collect($classes);
+
+        if (is_single() || is_page() && ! is_front_page()) {
+            if (! $classes->contains($class = basename(get_permalink()))) {
+                $classes->push($class);
+            }
+        }
+
+        return $classes->map(function ($class) {
+            return preg_replace(['/-blade(-php)?$/', '/^page-template-views/'], '', $class);
+        })
+        ->filter()
+        ->all();
+    }
+
+    /**
+     * Attach the body class filter.
+     *
      * @param  integer $priority
      * @return void
      */
-    public function attachBodyClassFilter($priority = 10)
+    protected function attachBodyClassFilter($priority = 10)
     {
-        add_filter('body_class', function (array $classes) {
-            /** Add page slug if it doesn't exist */
-            if (is_single() || is_page() && ! is_front_page()) {
-                if (! in_array(basename(get_permalink()), $classes)) {
-                    $classes[] = basename(get_permalink());
-                }
-            }
+        add_filter('body_class', [$this, 'filterBodyClass'], $priority);
+    }
 
-            /** Clean up class names for custom templates */
-            $classes = array_map(function ($class) {
-                return preg_replace(['/-blade(-php)?$/', '/^page-template-views/'], '', $class);
-            }, $classes);
-
-            return array_filter($classes);
-        }, $priority);
+    /**
+     * Use compiled Blade view when returning a template.
+     *
+     * @param  array $files
+     * @return void
+     */
+    public function filterTemplateHierarchy($files)
+    {
+        return $this->sageFinder->locate($files);
     }
 
     /**
@@ -160,7 +206,7 @@ class Sage
      * @param  integer $priority
      * @return void
      */
-    public function attachTemplateHierarchyFilters($priority = 10)
+    protected function attachTemplateHierarchyFilters($priority = 10)
     {
         add_filters([
             'index_template_hierarchy',
@@ -179,33 +225,40 @@ class Sage
             'single_template_hierarchy',
             'singular_template_hierarchy',
             'attachment_template_hierarchy',
-        ], function ($files) {
-            return $this->sageFinder->locate($files);
-        }, $priority);
+        ], [$this, 'filterTemplateHierarchy'], $priority);
     }
 
     /**
      * Include compiled Blade view with data attached.
      *
+     * @param  string
+     * @return string
+     */
+    public function filterTemplateInclude($file)
+    {
+        $view = $this->fileFinder
+            ->getPossibleViewNameFromPath(realpath($file));
+
+        /** Gather data to be passed to view */
+        $data = array_reduce(get_body_class(), function ($data, $class) use ($view, $file) {
+            return apply_filters("sage/template/{$class}/data", $data, $view, $file);
+        }, []);
+
+        $this->app['sage.view'] = $view;
+        $this->app['sage.data'] = $data;
+
+        return get_template_directory() . '/index.php';
+    }
+
+    /**
+     * Attach the template include filter.
+     *
      * @param  integer $priority
      * @return void
      */
-    public function attachTemplateIncludeFilter($priority = 100)
+    protected function attachTemplateIncludeFilter($priority = 100)
     {
-        add_filter('template_include', function ($file) {
-            $view = $this->fileFinder
-                ->getPossibleViewNameFromPath(realpath($file));
-
-            /** Gather data to be passed to view */
-            $data = array_reduce(get_body_class(), function ($data, $class) use ($view, $file) {
-                return apply_filters("sage/template/{$class}/data", $data, $view, $file);
-            }, []);
-
-            $this->app['sage.view'] = $view;
-            $this->app['sage.data'] = $data;
-
-            return get_template_directory() . '/index.php';
-        }, $priority);
+        add_filter('template_include', [$this, 'filterTemplateInclude'], $priority);
     }
 
     /**
@@ -213,49 +266,58 @@ class Sage
      *
      * @return void
      */
-    public function attachThemeTemplatesFilter($priority = 100)
+    public function filterThemeTemplates($_templates, $_theme, $_post, $post_type)
     {
-        add_filter('theme_templates', function ($_templates, $_theme, $_post, $post_type) {
-            $templates = [];
+        $templates = [];
 
-            foreach (array_reverse($this->fileFinder->getPaths()) as $path) {
-                /**
-                 * We use the exact same technique as WordPress core for detecting template files.
-                 *
-                 * Caveat: we go infinite levels deep within the views folder.
-                 *
-                 * @see \WP_Theme::get_post_templates()
-                 * @link https://github.com/WordPress/WordPress/blob/5.2.1/wp-includes/class-wp-theme.php#L1146-L1164
-                 */
-                foreach ($this->files->glob("{$path}/**.php") as $full_path) {
-                    if (! preg_match('|Template Name:(.*)$|mi', file_get_contents($full_path), $header)) {
-                        continue;
+        foreach (array_reverse($this->fileFinder->getPaths()) as $path) {
+            /**
+             * We use the exact same technique as WordPress core for detecting template files.
+             *
+             * Caveat: we go infinite levels deep within the views folder.
+             *
+             * @see \WP_Theme::get_post_templates()
+             * @link https://github.com/WordPress/WordPress/blob/5.2.1/wp-includes/class-wp-theme.php#L1146-L1164
+             */
+            foreach ($this->files->glob("{$path}/**.php") as $full_path) {
+                if (! preg_match('|Template Name:(.*)$|mi', file_get_contents($full_path), $header)) {
+                    continue;
+                }
+
+                $types = ['page'];
+
+                if (preg_match('|Template Post Type:(.*)$|mi', file_get_contents($full_path), $type)) {
+                    $types = explode(',', _cleanup_header_comment($type[1]));
+                }
+
+                $file = $this->files->getRelativePath("{$path}/", $full_path);
+
+                foreach ($types as $type) {
+                    $type = sanitize_key($type);
+
+                    if (! isset($templates[$type])) {
+                        $templates[$type] = [];
                     }
 
-                    $types = ['page'];
-
-                    if (preg_match('|Template Post Type:(.*)$|mi', file_get_contents($full_path), $type)) {
-                        $types = explode(',', _cleanup_header_comment($type[1]));
-                    }
-
-                    $file = $this->files->getRelativePath("{$path}/", $full_path);
-
-                    foreach ($types as $type) {
-                        $type = sanitize_key($type);
-
-                        if (! isset($templates[$type])) {
-                            $templates[$type] = [];
-                        }
-
-                        $templates[$type][$file] = _cleanup_header_comment($header[1]);
-                    }
+                    $templates[$type][$file] = _cleanup_header_comment($header[1]);
                 }
             }
+        }
 
-            return collect($_templates)
-                ->merge($templates[$post_type] ?? [])
-                ->unique()
-                ->toArray();
-        }, $priority, 4);
+        return collect($_templates)
+            ->merge($templates[$post_type] ?? [])
+            ->unique()
+            ->toArray();
+    }
+
+    /**
+     * Attach the theme templates filter.
+     *
+     * @param  integer $priority
+     * @return void
+     */
+    protected function attachThemeTemplatesFilter($priority = 100)
+    {
+        add_filter('theme_templates', [$this, 'filterThemeTemplates'], $priority, 4);
     }
 }

--- a/src/Acorn/Sage/Sage.php
+++ b/src/Acorn/Sage/Sage.php
@@ -13,41 +13,79 @@ use Roots\Acorn\View\FileViewFinder;
 
 class Sage
 {
-    /** @var \Illuminate\Contracts\Container\Container */
+    /**
+     * The container implementation.
+     *
+     * @var \Illuminate\Contracts\Container\Container
+     */
     protected $app;
 
-    /** @var \Roots\Acorn\Sage\ViewFinder */
-    protected $sage_finder;
+    /**
+     * The ViewFinder instance.
+     *
+     * @var \Roots\Acorn\Sage\ViewFinder
+     */
+    protected $sageFinder;
 
-    /** @var \Roots\Acorn\View\FileViewFinder */
-    protected $file_finder;
+    /**
+     * The FileViewFinder instance.
+     *
+     * @var \Roots\Acorn\View\FileViewFinder
+     */
+    protected $fileFinder;
 
-    /** @var \Illuminate\Contracts\View\Factory */
+    /**
+     * The View Factory instance.
+     *
+     * @var \Illuminate\Contracts\View\Factory
+     */
     protected $view;
 
+    /**
+     * Creates a new Sage instance.
+     *
+     * @param Filesystem        $files
+     * @param ViewFinder        $sageFinder
+     * @param FileViewFinder    $fileFinder
+     * @param ViewFactory       $view
+     * @param ContainerContract $app
+     */
     public function __construct(
         Filesystem $files,
-        ViewFinder $sage_finder,
-        FileViewFinder $file_finder,
+        ViewFinder $sageFinder,
+        FileViewFinder $fileFinder,
         ViewFactory $view,
         ContainerContract $app
     ) {
         $this->app = $app;
         $this->files = $files;
-        $this->file_finder = $file_finder;
-        $this->sage_finder = $sage_finder;
-        $this->view = $view;
+        $this->fileFinder = $fileFinder;
+        $this->sageFinder = $sageFinder;
+        $this->views = $view;
     }
 
+    /**
+     * Initialize and attach Sage features.
+     *
+     * @return void
+     */
     public function attach()
     {
         $this->attachPostVariable();
         $this->attachCommentsTemplateResolver();
+        $this->attachSearchFormFilter();
+        $this->attachBodyClassFilter();
         $this->attachTemplateHierarchyFilters();
         $this->attachTemplateIncludeFilter();
-        $this->attachThemeTemplateFilter();
+        $this->attachThemeTemplatesFilter();
     }
 
+    /**
+     * Attach global `$post` variable to Blade views.
+     *
+     * @param  integer $priority
+     * @return void
+     */
     public function attachPostVariable($priority = 10)
     {
         add_action('the_post', function ($post) {
@@ -55,11 +93,73 @@ class Sage
         }, $priority);
     }
 
+    /**
+     * Search for a compiled Blade partial when resolving the comments template.
+     *
+     * @param  integer $priority
+     * @return void
+     */
     public function attachCommentsTemplateResolver($priority = 100)
     {
-        add_filter('comments_template', [$this, 'commentsTemplateResolver'], $priority);
+        add_filter('comments_template', function ($name) {
+            if (Str::startsWith($file, [STYLESHEETPATH, TEMPLATEPATH])) {
+                $file = ltrim(str_replace([STYLESHEETPATH, TEMPLATEPATH], '', $file), '\\/');
+            }
+
+            if ($file == '/comments.php') {
+                $file = '/partials/comments.blade.php';
+            }
+
+            return view(
+                $this->fileFinder->getPossibleViewNameFromPath($file)
+            )->makeLoader();
+        }, $priority);
     }
 
+    /**
+     * Use search.blade.php for the search form.
+     *
+     * @param  integer $priority
+     * @return void
+     */
+    public function attachSearchFormFilter($priority = 100)
+    {
+        add_filter('get_search_form', function () {
+            return view('forms.search');
+        }, $priority);
+    }
+
+    /**
+     * Clean up the body class and append the page slug.
+     *
+     * @param  integer $priority
+     * @return void
+     */
+    public function attachBodyClassFilter($priority = 10)
+    {
+        add_filter('body_class', function (array $classes) {
+            /** Add page slug if it doesn't exist */
+            if (is_single() || is_page() && ! is_front_page()) {
+                if (! in_array(basename(get_permalink()), $classes)) {
+                    $classes[] = basename(get_permalink());
+                }
+            }
+
+            /** Clean up class names for custom templates */
+            $classes = array_map(function ($class) {
+                return preg_replace(['/-blade(-php)?$/', '/^page-template-views/'], '', $class);
+            }, $classes);
+
+            return array_filter($classes);
+        }, $priority);
+    }
+
+    /**
+     * Use compiled Blade view when returning a template.
+     *
+     * @param  integer $priority
+     * @return void
+     */
     public function attachTemplateHierarchyFilters($priority = 10)
     {
         add_filters([
@@ -79,107 +179,83 @@ class Sage
             'single_template_hierarchy',
             'singular_template_hierarchy',
             'attachment_template_hierarchy',
-        ], [$this, 'filterTemplateHierarchy'], $priority);
+        ], function ($files) {
+            return $this->sageFinder->locate($files);
+        }, $priority);
     }
 
+    /**
+     * Include compiled Blade view with data attached.
+     *
+     * @param  integer $priority
+     * @return void
+     */
     public function attachTemplateIncludeFilter($priority = 100)
     {
-        add_filter('template_include', [$this, 'loadView'], $priority);
+        add_filter('template_include', function ($file) {
+            $view = $this->fileFinder
+                ->getPossibleViewNameFromPath(realpath($file));
+
+            /** Gather data to be passed to view */
+            $data = array_reduce(get_body_class(), function ($data, $class) use ($view, $file) {
+                return apply_filters("sage/template/{$class}/data", $data, $view, $file);
+            }, []);
+
+            $this->app['sage.view'] = $view;
+            $this->app['sage.data'] = $data;
+
+            return get_template_directory() . '/index.php';
+        }, $priority);
     }
 
-    public function attachThemeTemplateFilter($priority = 100)
+    /**
+     * Add Blade compatability for post and page templates.
+     *
+     * @return void
+     */
+    public function attachThemeTemplatesFilter($priority = 100)
     {
-        add_filter('theme_templates', function ($post_templates, $_theme, $_post, $post_type) {
-            $theme_templates = $this->themeTemplates();
+        add_filter('theme_templates', function ($_templates, $_theme, $_post, $post_type) {
+            $templates = [];
 
-            return collect($post_templates)
-                ->merge($theme_templates[$post_type] ?? [])
+            foreach (array_reverse($this->fileFinder->getPaths()) as $path) {
+                /**
+                 * We use the exact same technique as WordPress core for detecting template files.
+                 *
+                 * Caveat: we go infinite levels deep within the views folder.
+                 *
+                 * @see \WP_Theme::get_post_templates()
+                 * @link https://github.com/WordPress/WordPress/blob/5.2.1/wp-includes/class-wp-theme.php#L1146-L1164
+                 */
+                foreach ($this->files->glob("{$path}/**.php") as $full_path) {
+                    if (! preg_match('|Template Name:(.*)$|mi', file_get_contents($full_path), $header)) {
+                        continue;
+                    }
+
+                    $types = ['page'];
+
+                    if (preg_match('|Template Post Type:(.*)$|mi', file_get_contents($full_path), $type)) {
+                        $types = explode(',', _cleanup_header_comment($type[1]));
+                    }
+
+                    $file = $this->files->getRelativePath("{$path}/", $full_path);
+
+                    foreach ($types as $type) {
+                        $type = sanitize_key($type);
+
+                        if (! isset($templates[$type])) {
+                            $templates[$type] = [];
+                        }
+
+                        $templates[$type][$file] = _cleanup_header_comment($header[1]);
+                    }
+                }
+            }
+
+            return collect($_templates)
+                ->merge($templates[$post_type] ?? [])
                 ->unique()
                 ->toArray();
         }, $priority, 4);
-    }
-
-    public function themeTemplates()
-    {
-        $post_templates = [];
-
-        foreach (array_reverse($this->file_finder->getPaths()) as $path) {
-            /**
-             * We use the exact same technique as WordPress core for detecting template files.
-             *
-             * Caveat: we go infinite levels deep within the views folder.
-             *
-             * @see \WP_Theme::get_post_templates()
-             * @link https://github.com/WordPress/WordPress/blob/5.2.1/wp-includes/class-wp-theme.php#L1146-L1164
-             */
-            foreach ($this->files->glob("{$path}/**.php") as $full_path) {
-                if (! preg_match('|Template Name:(.*)$|mi', file_get_contents($full_path), $header)) {
-                    continue;
-                }
-
-                $types = ['page'];
-                if (preg_match('|Template Post Type:(.*)$|mi', file_get_contents($full_path), $type)) {
-                    $types = explode(',', _cleanup_header_comment($type[1]));
-                }
-
-                $file = $this->files->getRelativePath("{$path}/", $full_path);
-
-                foreach ($types as $type) {
-                    $type = sanitize_key($type);
-                    if (! isset($post_templates[ $type ])) {
-                        $post_templates[$type] = [];
-                    }
-
-                    $post_templates[$type][$file] = _cleanup_header_comment($header[1]);
-                }
-            }
-        }
-
-        return $post_templates;
-    }
-
-    /**
-     * Transforms path to comments template into view name
-     *
-     * @internal Used by WordPress
-     * @param string $file Malformed path to comments template
-     * @return string Fully qualified path to view loader
-     */
-    public function commentsTemplateResolver($file)
-    {
-        if (Str::startsWith($file, [STYLESHEETPATH, TEMPLATEPATH])) {
-            $file = ltrim(str_replace([STYLESHEETPATH, TEMPLATEPATH], '', $file), '\\/');
-        }
-        $view = $this->file_finder->getPossibleViewNameFromPath($file);
-        return view($view)->makeLoader();
-    }
-
-    /**
-     * Template Hierarchy should search for .blade.php files
-     *
-     * @internal Used by WordPress
-     * @param string|array $path
-     */
-    public function filterTemplateHierarchy($files)
-    {
-        $views = $this->sage_finder->locate($files);
-
-        return $views;
-    }
-
-    public function loadView($file)
-    {
-        $view = $this->file_finder
-            ->getPossibleViewNameFromPath(realpath($file));
-
-        /** gather data to be passed to view */
-        $data = array_reduce(get_body_class(), function ($data, $class) use ($view, $file) {
-            return apply_filters("sage/template/{$class}/data", $data, $view, $file);
-        }, []);
-
-        $this->app['sage.view'] = $view;
-        $this->app['sage.data'] = $data;
-
-        return get_template_directory() . '/index.php';
     }
 }

--- a/src/Acorn/Sage/Sage.php
+++ b/src/Acorn/Sage/Sage.php
@@ -2,8 +2,6 @@
 
 namespace Roots\Acorn\Sage;
 
-use function Roots\add_filters;
-use function Roots\view;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Support\Str;
@@ -13,32 +11,21 @@ use Roots\Acorn\View\FileViewFinder;
 
 class Sage
 {
-    /**
-     * The container implementation.
-     *
-     * @var \Illuminate\Contracts\Container\Container
-     */
+    use Concerns\FiltersBodyClass,
+        Concerns\FiltersTemplates,
+        Concerns\FiltersThePost,
+        Concerns\FiltersViews;
+
+    /** @var \Illuminate\Contracts\Container\Container */
     protected $app;
 
-    /**
-     * The ViewFinder instance.
-     *
-     * @var \Roots\Acorn\Sage\ViewFinder
-     */
+    /** @var \Roots\Acorn\Sage\ViewFinder */
     protected $sageFinder;
 
-    /**
-     * The FileViewFinder instance.
-     *
-     * @var \Roots\Acorn\View\FileViewFinder
-     */
+    /** @var \Roots\Acorn\View\FileViewFinder */
     protected $fileFinder;
 
-    /**
-     * The View Factory instance.
-     *
-     * @var \Illuminate\Contracts\View\Factory
-     */
+    /** @var \Illuminate\Contracts\View\Factory */
     protected $view;
 
     /**
@@ -65,259 +52,15 @@ class Sage
     }
 
     /**
-     * Initialize and attach Sage features.
+     * Get filter to be passed to WordPress
      *
-     * @return void
-     */
-    public function attach()
-    {
-        $this->attachPostFilter();
-        $this->attachCommentsTemplateFilter();
-        $this->attachSearchFormFilter();
-        $this->attachBodyClassFilter();
-        $this->attachTemplateHierarchyFilters();
-        $this->attachTemplateIncludeFilter();
-        $this->attachThemeTemplatesFilter();
-    }
-
-    /**
-     * Attach global `$post` variable to Blade views.
-     *
-     * @param  WP_Post $post
-     * @return void
-     */
-    public function filterPost($post)
-    {
-        $this->view->share('post', $post);
-    }
-
-    /**
-     * Attach the post filter.
-     *
-     * @param  integer $priority
-     * @return void
-     */
-    protected function attachPostFilter($priority = 10)
-    {
-        add_action('the_post', [$this, 'filterPost'], $priority);
-    }
-
-    /**
-     * Search for a compiled Blade partial when resolving the comments template.
-     *
-     * @param  string $file
-     * @return string
-     */
-    public function filterCommentsTemplate($file)
-    {
-        if (Str::startsWith($file, [STYLESHEETPATH, TEMPLATEPATH])) {
-            $file = ltrim(str_replace([STYLESHEETPATH, TEMPLATEPATH], '', $file), '\\/');
-        }
-
-        if ($file == 'comments.php') {
-            $file = 'partials/comments.blade.php';
-        }
-
-        return view(
-            $this->fileFinder->getPossibleViewNameFromPath($file)
-        )->makeLoader();
-    }
-
-    /**
-     * Attach the comments template filter.
-     *
-     * @param  integer $priority
-     * @return void
-     */
-    protected function attachCommentsTemplateFilter($priority = 100)
-    {
-        add_filter('comments_template', [$this, 'filterCommentsTemplate'], $priority);
-    }
-
-    /**
-     * Use `forms/search.blade.php` for the search form.
-     *
-     * @return string
-     */
-    public function filterSearchForm()
-    {
-        return view('forms.search');
-    }
-
-    /**
-     * Attach the search form filter.
-     *
-     * @param  integer $priority
-     * @return void
-     */
-    protected function attachSearchFormFilter($priority = 100)
-    {
-        add_filter('get_search_form', [$this, 'filterSearchForm'], $priority);
-    }
-
-    /**
-     * Clean up the body class and append the page slug.
-     *
-     * @param  array $classes
      * @return array
      */
-    public function filterBodyClass($classes)
+    public function filter($filter)
     {
-        $classes = collect($classes);
-
-        if (is_single() || is_page() && ! is_front_page()) {
-            if (! $classes->contains($class = basename(get_permalink()))) {
-                $classes->push($class);
-            }
+        if (method_exists($this, $filter)) {
+            return [$this, $filter];
         }
-
-        return $classes->map(function ($class) {
-            return preg_replace(['/-blade(-php)?$/', '/^page-template-views/'], '', $class);
-        })
-        ->filter()
-        ->all();
-    }
-
-    /**
-     * Attach the body class filter.
-     *
-     * @param  integer $priority
-     * @return void
-     */
-    protected function attachBodyClassFilter($priority = 10)
-    {
-        add_filter('body_class', [$this, 'filterBodyClass'], $priority);
-    }
-
-    /**
-     * Use compiled Blade view when returning a template.
-     *
-     * @param  array $files
-     * @return void
-     */
-    public function filterTemplateHierarchy($files)
-    {
-        return $this->sageFinder->locate($files);
-    }
-
-    /**
-     * Use compiled Blade view when returning a template.
-     *
-     * @param  integer $priority
-     * @return void
-     */
-    protected function attachTemplateHierarchyFilters($priority = 10)
-    {
-        add_filters([
-            'index_template_hierarchy',
-            '404_template_hierarchy',
-            'archive_template_hierarchy',
-            'author_template_hierarchy',
-            'category_template_hierarchy',
-            'tag_template_hierarchy',
-            'taxonomy_template_hierarchy',
-            'date_template_hierarchy',
-            'home_template_hierarchy',
-            'frontpage_template_hierarchy',
-            'page_template_hierarchy',
-            'paged_template_hierarchy',
-            'search_template_hierarchy',
-            'single_template_hierarchy',
-            'singular_template_hierarchy',
-            'attachment_template_hierarchy',
-        ], [$this, 'filterTemplateHierarchy'], $priority);
-    }
-
-    /**
-     * Include compiled Blade view with data attached.
-     *
-     * @param  string
-     * @return string
-     */
-    public function filterTemplateInclude($file)
-    {
-        $view = $this->fileFinder
-            ->getPossibleViewNameFromPath(realpath($file));
-
-        /** Gather data to be passed to view */
-        $data = array_reduce(get_body_class(), function ($data, $class) use ($view, $file) {
-            return apply_filters("sage/template/{$class}/data", $data, $view, $file);
-        }, []);
-
-        $this->app['sage.view'] = $view;
-        $this->app['sage.data'] = $data;
-
-        return get_template_directory() . '/index.php';
-    }
-
-    /**
-     * Attach the template include filter.
-     *
-     * @param  integer $priority
-     * @return void
-     */
-    protected function attachTemplateIncludeFilter($priority = 100)
-    {
-        add_filter('template_include', [$this, 'filterTemplateInclude'], $priority);
-    }
-
-    /**
-     * Add Blade compatability for post and page templates.
-     *
-     * @return void
-     */
-    public function filterThemeTemplates($_templates, $_theme, $_post, $post_type)
-    {
-        $templates = [];
-
-        foreach (array_reverse($this->fileFinder->getPaths()) as $path) {
-            /**
-             * We use the exact same technique as WordPress core for detecting template files.
-             *
-             * Caveat: we go infinite levels deep within the views folder.
-             *
-             * @see \WP_Theme::get_post_templates()
-             * @link https://github.com/WordPress/WordPress/blob/5.2.1/wp-includes/class-wp-theme.php#L1146-L1164
-             */
-            foreach ($this->files->glob("{$path}/**.php") as $full_path) {
-                if (! preg_match('|Template Name:(.*)$|mi', file_get_contents($full_path), $header)) {
-                    continue;
-                }
-
-                $types = ['page'];
-
-                if (preg_match('|Template Post Type:(.*)$|mi', file_get_contents($full_path), $type)) {
-                    $types = explode(',', _cleanup_header_comment($type[1]));
-                }
-
-                $file = $this->files->getRelativePath("{$path}/", $full_path);
-
-                foreach ($types as $type) {
-                    $type = sanitize_key($type);
-
-                    if (! isset($templates[$type])) {
-                        $templates[$type] = [];
-                    }
-
-                    $templates[$type][$file] = _cleanup_header_comment($header[1]);
-                }
-            }
-        }
-
-        return collect($_templates)
-            ->merge($templates[$post_type] ?? [])
-            ->unique()
-            ->toArray();
-    }
-
-    /**
-     * Attach the theme templates filter.
-     *
-     * @param  integer $priority
-     * @return void
-     */
-    protected function attachThemeTemplatesFilter($priority = 100)
-    {
-        add_filter('theme_templates', [$this, 'filterThemeTemplates'], $priority, 4);
+        return [$this, 'filter' . Str::studly($filter)];
     }
 }

--- a/src/Acorn/Sage/SageServiceProvider.php
+++ b/src/Acorn/Sage/SageServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Roots\Acorn\Sage;
 
 use function Roots\add_filters;
-
 use Roots\Acorn\Config;
 use Roots\Acorn\Sage\Sage;
 use Roots\Acorn\Sage\ViewFinder;
@@ -21,7 +20,59 @@ class SageServiceProvider extends ServiceProvider
     public function boot()
     {
         if ($this->app->bound('view')) {
-            $this->app['sage']->attach();
+            $this->bindCompatFilters();
+            $this->bindViewFilters();
         }
+    }
+
+    /**
+     * Sage compatibility filters
+     *
+     * These are filters that are required for Sage features to operate correctly
+     *
+     * @return void
+     */
+    protected function bindCompatFilters()
+    {
+        $sage = $this->app['sage'];
+
+        add_filter('body_class', $sage->filter('body_class'), 10);
+        add_action('the_post', $sage->filter('the_post'), 10);
+        add_filter('template_include', $sage->filter('template_include'), 100);
+        add_filter('theme_templates', $sage->filter('theme_templates'), 100, 4);
+
+        add_filters([
+            'index_template_hierarchy',
+            '404_template_hierarchy',
+            'archive_template_hierarchy',
+            'author_template_hierarchy',
+            'category_template_hierarchy',
+            'tag_template_hierarchy',
+            'taxonomy_template_hierarchy',
+            'date_template_hierarchy',
+            'home_template_hierarchy',
+            'frontpage_template_hierarchy',
+            'page_template_hierarchy',
+            'paged_template_hierarchy',
+            'search_template_hierarchy',
+            'single_template_hierarchy',
+            'singular_template_hierarchy',
+            'attachment_template_hierarchy',
+        ], $sage->filter('template_hierarchy'), 10);
+    }
+
+    /**
+     * Sage view filters
+     *
+     * These filters direct WordPress to views within Sage.
+     *
+     * @return void
+     */
+    protected function bindViewFilters()
+    {
+        $sage = $this->app['sage'];
+
+        add_filter('comments_template', $sage->filter('comments_template'), 100);
+        add_filter('get_search_form', $sage->filter('search_form'), 100);
     }
 }

--- a/src/Acorn/View/ViewServiceProvider.php
+++ b/src/Acorn/View/ViewServiceProvider.php
@@ -42,6 +42,16 @@ class ViewServiceProvider extends ViewServiceProviderBase
     }
 
     /**
+     * Return an instance of View.
+     *
+     * @return Illuminate\View\View
+     */
+    protected function view()
+    {
+        return $this->app['view'];
+    }
+
+    /**
      * Register View Finder
      *
      * @return void
@@ -112,10 +122,10 @@ class ViewServiceProvider extends ViewServiceProviderBase
      */
     public function preflight(Filesystem $files)
     {
-        $compiled_dir = $this->app['config']['view.compiled'];
+        $storageDir = $this->app['config']['view.compiled'];
 
-        if (! $files->exists($compiled_dir)) {
-            $files->makeDirectory($compiled_dir, 0755, true);
+        if (! $files->exists($storageDir)) {
+            $files->makeDirectory($storageDir, 0755, true);
         }
     }
 
@@ -126,7 +136,7 @@ class ViewServiceProvider extends ViewServiceProviderBase
      */
     public function attachDirectives()
     {
-        $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
+        $blade = $this->view()->getEngineResolver()->resolve('blade')->getCompiler();
         $directives = $this->app['config']['view.directives'];
         $directives += ['inject' => InjectionDirective::class];
 
@@ -149,7 +159,7 @@ class ViewServiceProvider extends ViewServiceProviderBase
         $components = $this->app->config['view.components'];
 
         if (is_array($components) && Arr::isAssoc($components)) {
-            $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
+            $blade = $this->view()->getEngineResolver()->resolve('blade')->getCompiler();
 
             foreach ($components as $alias => $view) {
                 $blade->component($view, $alias);
@@ -164,10 +174,8 @@ class ViewServiceProvider extends ViewServiceProviderBase
      */
     public function attachComposers()
     {
-        $view = $this->app['view'];
-
         foreach ($this->app->config['view.composers'] as $composer) {
-            $view->composer($composer::views(), $composer);
+            $this->view()->composer($composer::views(), $composer);
         }
 
         $paths = collect($this->app->path('Composers'))
@@ -191,7 +199,7 @@ class ViewServiceProvider extends ViewServiceProviderBase
 
             if (is_subclass_of($composer, Composer::class) &&
                 ! (new ReflectionClass($composer))->isAbstract()) {
-                $view->composer($composer::views(), $composer);
+                $this->view()->composer($composer::views(), $composer);
             }
         }
     }
@@ -203,6 +211,6 @@ class ViewServiceProvider extends ViewServiceProviderBase
      */
     public function attachDebugger()
     {
-        $this->app['view']->composer('*', Debugger::class);
+        $this->view()->composer('*', Debugger::class);
     }
 }

--- a/src/Acorn/View/ViewServiceProvider.php
+++ b/src/Acorn/View/ViewServiceProvider.php
@@ -2,33 +2,70 @@
 
 namespace Roots\Acorn\View;
 
+use ReflectionClass;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 use Illuminate\View\ViewServiceProvider as ViewServiceProviderBase;
+use Symfony\Component\Finder\Finder;
 use Roots\Acorn\View\Composers\Debugger;
 use Roots\Acorn\View\Directives\InjectionDirective;
 
 class ViewServiceProvider extends ViewServiceProviderBase
 {
+    /**
+     * Register services.
+     *
+     * @return void
+     */
     public function register()
     {
         parent::register();
         $this->registerMacros();
     }
 
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->attachDirectives();
+        $this->attachComponents();
+        $this->attachComposers();
+
+        if ($this->app['config']['view.debug']) {
+            $this->attachDebugger();
+        }
+    }
+
+    /**
+     * Register View Finder
+     *
+     * @return void
+     */
     public function registerViewFinder()
     {
         $this->app->bind('view.finder', function ($app) {
             $finder = new FileViewFinder($app['files'], array_unique($app['config']['view.paths']));
+
             foreach ($app['config']['view.namespaces'] as $namespace => $hints) {
                 $finder->addNamespace($namespace, $hints);
             }
+
             return $finder;
         });
+
         $this->app->alias('view.finder', FileViewFinder::class);
     }
 
+    /**
+     * Register View Macros
+     *
+     * @return void
+     */
     public function registerMacros()
     {
         /**
@@ -58,24 +95,21 @@ class ViewServiceProvider extends ViewServiceProviderBase
             $compiled = $this->getCompiled();
             $id = basename($compiled, '.php');
             $loader = dirname($compiled) . "/{$id}-loader.php";
+
             if (! file_exists($loader)) {
                 file_put_contents($loader, "<?= \\Roots\\view('{$view}', \$data ?? get_defined_vars()); ?>");
             }
+
             return $loader;
         });
     }
 
-    public function boot()
-    {
-        $this->attachDirectives();
-        $this->attachComponents();
-        $this->attachComposers();
-
-        if ($this->app['config']['view.debug']) {
-            $this->attachDebugger();
-        }
-    }
-
+    /**
+     * Preflight
+     *
+     * @param  Filesystem $files
+     * @return void
+     */
     public function preflight(Filesystem $files)
     {
         $compiled_dir = $this->app['config']['view.compiled'];
@@ -85,39 +119,88 @@ class ViewServiceProvider extends ViewServiceProviderBase
         }
     }
 
+    /**
+     * Attach View Directives
+     *
+     * @return void
+     */
     public function attachDirectives()
     {
         $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
         $directives = $this->app['config']['view.directives'];
         $directives += ['inject' => InjectionDirective::class];
+
         foreach ($directives as $name => $handler) {
             if (! is_callable($handler)) {
                 $handler = $this->app->make($handler);
             }
+
             $blade->directive($name, $handler);
         }
     }
 
+    /**
+     * Attach View Components
+     *
+     * @return void
+     */
     public function attachComponents()
     {
         $components = $this->app->config['view.components'];
 
         if (is_array($components) && Arr::isAssoc($components)) {
             $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
+
             foreach ($components as $alias => $view) {
                 $blade->component($view, $alias);
             }
         }
     }
 
+    /**
+     * Attach View Composers
+     *
+     * @return void
+     */
     public function attachComposers()
     {
         $view = $this->app['view'];
+
         foreach ($this->app->config['view.composers'] as $composer) {
             $view->composer($composer::views(), $composer);
         }
+
+        $paths = collect($this->app->path('Composers'))
+            ->unique()
+            ->filter(function ($path) {
+                return is_dir($path);
+            });
+
+        if ($paths->isEmpty()) {
+            return;
+        }
+
+        $namespace = $this->app->getNamespace();
+
+        foreach ((new Finder())->in($paths->all())->files() as $composer) {
+            $composer = $namespace . str_replace(
+                ['/', '.php'],
+                ['\\', ''],
+                Str::after($composer->getPathname(), realpath($this->app->path()) . DIRECTORY_SEPARATOR)
+            );
+
+            if (is_subclass_of($composer, Composer::class) &&
+                ! (new ReflectionClass($composer))->isAbstract()) {
+                $view->composer($composer::views(), $composer);
+            }
+        }
     }
 
+    /**
+     * Attach View Debugger
+     *
+     * @return void
+     */
     public function attachDebugger()
     {
         $this->app['view']->composer('*', Debugger::class);


### PR DESCRIPTION
## Change log

- Use `app.globals` for enabling global helpers instead of a filter    
- Set default timezone using `app.timezone`
- Set default mb encoding to `UTF-8`
- Add docblocks to Sage class
- Clean up Sage class, move to anonymous functions
- Add default comments template (`partials/comments.blade.php`)
- Move Search Form filter from Sage to Acorn
- Move Body Class filter from Sage to Acorn
- **Add Composer autoloading** (#29)

Sage has already been updated to include `app.timezone` and `app.globals`. If you're down with moving the filters over, I'll remove them from Sage as well as remove the specific defining `/partials/comments.blade.php` in partials such as `content-single.blade.php`.