### PR TITLE
Fixes call to Illuminate\Support\Str

### DIFF
--- a/src/Acorn/Sage/Concerns/FiltersViews.php
+++ b/src/Acorn/Sage/Concerns/FiltersViews.php
@@ -3,6 +3,7 @@
 namespace Roots\Acorn\Sage\Concerns;
 
 use function Roots\view;
+use Illuminate\Support\Str;
 
 trait FiltersViews
 {


### PR DESCRIPTION
Was throwing an error when attempting to resolve the comments template. This change fixes it.