### PR TITLE
feat(view): Add view composer traits

### DIFF
--- a/src/Acorn/View/Composer.php
+++ b/src/Acorn/View/Composer.php
@@ -2,12 +2,16 @@
 
 namespace Roots\Acorn\View;
 
-use Illuminate\View\View;
 use Illuminate\Support\Str;
+use Illuminate\View\View;
 
 abstract class Composer
 {
+    /** @var string[] List of views to receive data by this composer */
     protected static $views;
+
+    /** @var \Illuminate\View\View Current view */
+    protected $view;
 
     /**
      * List of views served by this composer
@@ -33,21 +37,31 @@ abstract class Composer
      */
     public function compose(View $view)
     {
-        $view->with(array_merge(
-            $this->with($view->getData(), $view),
-            $view->getData(),
-            $this->override($view->getData(), $view)
-        ));
+        $this->view = $view;
+
+        $view->with($this->getData());
     }
 
     /**
      * Data to be passed to view before rendering
      *
-     * @param array $data
-     * @param \Illuminate\View\View $view
      * @return array
      */
-    public function override($data, $view)
+    protected function getData()
+    {
+        return array_merge(
+            $this->with(),
+            $this->view->getData(),
+            $this->override()
+        );
+    }
+
+    /**
+     * Data to be passed to view before rendering
+     *
+     * @return array
+     */
+    protected function with()
     {
         return [];
     }
@@ -55,11 +69,9 @@ abstract class Composer
     /**
      * Data to be passed to view before rendering
      *
-     * @param array $data
-     * @param \Illuminate\View\View $view
      * @return array
      */
-    public function with($data, $view)
+    protected function override()
     {
         return [];
     }

--- a/src/Acorn/View/Composers/Concerns/AcfFields.php
+++ b/src/Acorn/View/Composers/Concerns/AcfFields.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Roots\Acorn\View\Composers\Concerns;
+
+use Illuminate\Support\Fluent;
+
+trait AcfFields
+{
+    /**
+     * ACF data to be passed to view before rendering
+     *
+     * @return array
+     */
+    protected function fields($post_id = null)
+    {
+        $acf_data = \get_fields($post_id);
+
+        return array_map(function ($value, $key) {
+            $value = is_array($value) ? new Fluent($value) : $value;
+            return method_exists($this, $key) ? $this->{$key}($value) : $value;
+        }, $acf_data, array_keys($acf_data));
+    }
+}

--- a/src/Acorn/View/Composers/Concerns/Arrayable.php
+++ b/src/Acorn/View/Composers/Concerns/Arrayable.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Roots\Acorn\View\Composers\Concerns;
+
+use Illuminate\Support\Fluent;
+use Illuminate\Support\Str;
+
+trait Arrayable
+{
+    protected $ignore = [];
+
+    public function toArray()
+    {
+        return collect((new \ReflectionClass(static::class))->getMethods(\ReflectionMethod::IS_PUBLIC))
+            ->filter(function ($method) {
+                return ! in_array($method->name, array_merge($this->ignore, ['compose', 'toArray', 'with', 'views', 'override']));
+            })
+            ->filter(function ($method) {
+                return ! Str::startsWith($method->name, ['__', 'cache']);
+            })
+            ->mapWithKeys(function ($method) {
+                $data = $this->{$method->name}();
+                return [$method->name => is_array($data) ? new Fluent($data) : $data];
+            })
+            ->all();
+    }
+}

--- a/src/Acorn/View/Composers/Concerns/Arrayable.php
+++ b/src/Acorn/View/Composers/Concerns/Arrayable.php
@@ -13,7 +13,10 @@ trait Arrayable
     {
         return collect((new \ReflectionClass(static::class))->getMethods(\ReflectionMethod::IS_PUBLIC))
             ->filter(function ($method) {
-                return ! in_array($method->name, array_merge($this->ignore, ['compose', 'toArray', 'with', 'views', 'override']));
+                return ! in_array($method->name, array_merge(
+                    $this->ignore,
+                    ['compose', 'toArray', 'with', 'views', 'override']
+                ));
             })
             ->filter(function ($method) {
                 return ! Str::startsWith($method->name, ['__', 'cache']);

--- a/src/Acorn/View/Composers/Concerns/Cacheable.php
+++ b/src/Acorn/View/Composers/Concerns/Cacheable.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Roots\Acorn\View\Composers\Concerns;
+
+use function Roots\cache;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\View\View;
+
+trait Cacheable
+{
+    /**
+     * Cache expiration
+     *
+     * If no expiration is specified, the values will be cached forever.
+     *
+     * @var int|float
+     */
+    protected $cache_expiration;
+
+    /**
+     * Cache key
+     *
+     * If no key is specified, the key will default to the class name and post ID
+     *
+     * @var string
+     */
+    protected $cache_key;
+
+    /**
+     * Cache tags
+     *
+     * If no tags are specified, the tags will be class name, post ID, and post type
+     *
+     * @var string[]
+     */
+    protected $cache_tags;
+
+    /**
+     * Cache helper
+     *
+     * @param  dynamic  key|key,value|key-values|null
+     * @return mixed
+     *
+     * @throws \BadMethodCallException
+     */
+    public function cache()
+    {
+        static $cache;
+
+        $arguments = func_get_args();
+        $tags = $this->cache_tags ?? [static::class, 'post-' . get_the_ID(), get_post_type()];
+
+        if (! $cache) {
+            try {
+                $cache = Cache::tags($tags);
+            } catch (\BadMethodCallException $error) {
+                $cache = cache();
+            }
+        }
+
+        if (empty($arguments)) {
+            return $cache;
+        }
+
+        if (! is_string($values = $arguments[0])) {
+            $data = [];
+
+            foreach ($values as $key => $value) {
+                $data[$key] = $this->cache($key, $value);
+            }
+
+            return $data;
+        }
+
+        if (! isset($arguments[1])) {
+            return $cache->get($arguments[0]);
+        }
+
+        $key = $arguments[0];
+        $value = $arguments[1];
+
+        if (! is_callable($value)) {
+            throw new \BadMethodCallException('Cache value should be callable');
+        }
+
+        if (! $expires = $this->cache_expiration) {
+            return $cache->rememberForever($key, $value);
+        }
+
+        return $cache->remember($key, $expires, $value);
+    }
+
+    /**
+     * Forget cache data
+     *
+     * @param string $key
+     * @return void
+     */
+    protected function forget($key = null)
+    {
+        return $this->cache()->forget($key ?? static::class . get_the_ID());
+    }
+
+    /**
+     * Flush all cache data
+     *
+     * If tags are supported, then only the tags will be flushed
+     *
+     * @return void
+     */
+    protected function flush()
+    {
+        return $this->cache()->flush();
+    }
+
+    /**
+     * Data to be passed to view before rendering
+     *
+     * @return array
+     */
+    protected function getData()
+    {
+        $key = $this->cache_key ?? hash('crc32b', static::class . serialize(
+            get_queried_object()
+            ?? collect($_SERVER)->only('HTTP_HOST', 'REQUEST_URI', 'QUERY_STRING', 'WP_HOME')->toArray()
+        ));
+
+        $with = $this->cache($key, function () {
+            return $this->with();
+        });
+
+        return array_merge(
+            $with,
+            $this->view->getData(),
+            $this->override()
+        );
+    }
+}


### PR DESCRIPTION
3 new View Composer traits

## AcfFields.

Adds a `::fields($post_id = null)` method to the composer that returns all ACF Fields.

Usage:
```php
    public function with()
    {
        return $this->fields();
    }
```

## Cacheable.

Adds a `::cache()`, `::forget()`, and `::flush()` methods to the composer. By default all data in the composer is cached indefinitely. We can discuss whether these defaults should be changed.

Usage:
It just works.™

## Arrayable.

Adds `::toArray()` to the composer. It collects all public methods on the composer and returns their output.

Usage:
```php
    public function with()
    {
        return $this->toArray(); // output: ['title' => $this->title(), etc...]
    }

    public function title()
    {
        // ...
    }

    public function description()
    {
        // ...
    }

    public function price()
    {
        // ...
    }
```