### PR TITLE
feat(view): support vendor/{namespace} paths

### DIFF
--- a/src/Acorn/View/ViewServiceProvider.php
+++ b/src/Acorn/View/ViewServiceProvider.php
@@ -62,6 +62,10 @@ class ViewServiceProvider extends ViewServiceProviderBase
             $finder = new FileViewFinder($app['files'], array_unique($app['config']['view.paths']));
 
             foreach ($app['config']['view.namespaces'] as $namespace => $hints) {
+                $hints = array_merge(array_map(function ($path) use ($namespace) {
+                    return "{$path}/vendor/{$namespace}";
+                }, $finder->getPaths()), (array) $hints);
+                
                 $finder->addNamespace($namespace, $hints);
             }
 


### PR DESCRIPTION
I haven't fully tested this, but the idea is that if a user defines a namespaced view path, this will automatically prepend vendor paths within the default view paths.

Example:
```
    /*
    |--------------------------------------------------------------------------
    | View Namespaces
    |--------------------------------------------------------------------------
    |
    | Blade has an underutilized feature that allows developers to add
    | supplemental view paths that may contain conflictingly named views.
    | These paths are prefixed with a namespace to get around the conflicts.
    | A use case might be including views from within a plugin folder.
    |
    */

    'namespaces' => [
        /*
         | Given the below example, in your views use something like:
         |     @include('MyPlugin::some.view.or.partial.here')
         */
        'wc' => WP_PLUGIN_DIR . '/woocommerce/templates',
    ],
```

Before searching for a namespaced view in `WP_PLUGIN_DIR . '/woocommerce/templates/'`, the View engine will first search in, for example, `sage/resources/views/vendor/wc/`, where `wc` corresponds to the specified namespace.

This allows developers to namespace their views however they want and generally not have to worry about whether a plugin is going to search in `sage/woocommerce` or `sage/resources/views/woocommerce` or whatever.