### PR TITLE
Add additional placeholders to replaceClass

### DIFF
--- a/src/Acorn/Console/Commands/GeneratorCommand.php
+++ b/src/Acorn/Console/Commands/GeneratorCommand.php
@@ -202,7 +202,11 @@ abstract class GeneratorCommand extends Command
     {
         $class = str_replace($this->getNamespace($name) . '\\', '', $name);
 
-        return str_replace('DummyClass', $class, $stub);
+        return str_replace(
+            ['DummyClass', 'DummySlug', 'DummyCamel', 'DummySnake'],
+            [$class, Str::slug($class), Str::camel($class), Str::snake($class)],
+            $slug
+        );
     }
 
     /**


### PR DESCRIPTION
Adds `DummySlug`, `DummyCamel`, and `DummySnake` to `GeneratorCommand`'s `replaceClass()` method allowing for more flexibility with scaffold generation.

This is currently being used in the new Clover, but will be useful for a few of our stubs on Acorn as well.