### PR TITLE
feature(asset): add toJson() method for reading asset manifests, etc.

### DIFF
--- a/src/Acorn/Assets/Asset.php
+++ b/src/Acorn/Assets/Asset.php
@@ -75,6 +75,20 @@ class Asset implements AssetContract
         return include $this->path();
     }
 
+    /**
+     * Get and decode the JSON contents of the asset
+     *
+     * @return array
+     */
+    public function toJson()
+    {
+        if (! $this->contents()) {
+            return false;
+        }
+
+        return json_decode($this->contents(), true);
+    }
+
     /** {@inheritdoc} */
     public function __toString()
     {


### PR DESCRIPTION
Necessary little helper for stuff that require you to read the manifest like Encore's `entrypoints.json`, etc.

Will also clean up the Sage 10 implementation of [https://github.com/roots/palette-webpack-plugin](palette-webpack-plugin)