### PR TITLE
Update Composer stub - remove method arguments

### DIFF
--- a/src/Acorn/Console/Commands/stubs/composer.stub
+++ b/src/Acorn/Console/Commands/stubs/composer.stub
@@ -18,11 +18,9 @@ class DummyClass extends Composer
     /**
      * Data to be passed to view before rendering.
      *
-     * @param  array $data
-     * @param  \Illuminate\View\View $view
      * @return array
      */
-    public function with($data, $view)
+    public function with()
     {
         return [
             //


### PR DESCRIPTION
Since bcd77fa66b5311d890cfdfbeb9f43fce4f54714e the methods `with()` and `override()` don't have any arguments. Therefor the declaration should be compatible.