### PR TITLE
Potential fix for broken view autoloading

### DIFF
--- a/src/Acorn/View/Composer.php
+++ b/src/Acorn/View/Composer.php
@@ -41,6 +41,9 @@ abstract class Composer
         }
 
         $view = array_slice(explode('\\', static::class), 2);
+        if (isset($view[0]) && 'Composers' === $view[0]) {
+            unset($view[0]);
+        }
         $view = array_map([Str::class, 'snake'], $view, array_fill(0, count($view), '-'));
         return implode('/', $view);
     }


### PR DESCRIPTION
In previous releases, you could forgo adding a `$views` prop if your namespacing and class names reflected the structure of your views. It looks (??) like a namespacing change at some point broke this, as I wasn't able to get it to work on a recent project.

This commit fixes the issue, but is likely just a hack; consider this a prompt for a better solution if mine is problematic.