### PR TITLE
Add Laravel Mix HMR feature compatibility

### DIFF
--- a/src/Acorn/Assets/AssetsMixable.php
+++ b/src/Acorn/Assets/AssetsMixable.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Roots\Acorn\Assets;
+
+use Illuminate\Support\Str;
+
+trait AssetsMixable
+{
+    /**
+     * Get the URI to a Mix hot module replacement server.
+     *
+     * @link https://laravel-mix.com/docs/hot-module-replacement
+     *
+     * @param  string $path
+     * @return string
+     */
+    protected function getMixHotUri(string $path): ?string
+    {
+        if (file_exists($path . '/hot')) {
+            $url = rtrim(rtrim(file_get_contents($path . '/hot')), '/');
+
+            return Str::after($url, ':');
+        }
+
+        return null;
+    }
+}

--- a/src/Acorn/Assets/RelativePathManifest.php
+++ b/src/Acorn/Assets/RelativePathManifest.php
@@ -18,6 +18,8 @@ class RelativePathManifest implements
     \JsonSerializable,
     ManifestContract
 {
+    use AssetsMixable;
+
     /** @var array */
     protected $manifest;
 
@@ -39,6 +41,11 @@ class RelativePathManifest implements
     {
         $this->path = $path;
         $this->uri = $uri;
+
+        if ($mixHotUri = $this->getMixHotUri($path)) {
+            $this->uri = $mixHotUri;
+        }
+
         $manifest = $manifest instanceof Arrayable ? $manifest->toArray() : (array) $manifest;
 
         foreach ($manifest as $key => $value) {


### PR DESCRIPTION
This little addition targets to provide support for Laravel Mix "native" Hot Module Replacement for all Acorn-based development.

"Native" means BrowserSync is no more required, neither any proxying tools.

* User documentation: https://laravel-mix.com/docs/5.0/hot-module-replacement
* Laravel source: https://github.com/laravel/framework/blob/7ebd21193df520d78269d7abd740537a2fae889e/src/Illuminate/Foundation/Mix.php#L32-L40

### Pros

* Use all the power of webpack-dev-server via laravel-mix
* Usage is really straightforward
  * No special/additional configuration
  * No additional dependencies
* No more proxy required
  * The same address can be used with or without HMR
  * HMR handling script is added to build assets automatically
* We can get rid of browsersync
  * BS is really hard to configure, specially with a PHP development ([just take a look how many issue/pr are related to BS](https://github.com/roots/sage/search?q=browsersync&type=Issues))
  * BS is not actively maintained anymore
* The addition won't change anything if laraval-mix HMR is not used
* The trait can be reused by any assets manifest class

### Cons

* By using this, we loose browsersync special features, like multi-tab management. (did we really use them? 😇)