### PR TITLE
fix(helpers): view() should support file paths

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -404,7 +404,8 @@ function view($view = null, $data = [], $mergeData = [])
         return $factory;
     }
 
-    return $factory->make($view, $data, $mergeData);
+    return $factory->exists($view)
+        ? $factory->make($view, $data, $mergeData) : $factory->file($view, $data, $mergeData);
 }
 
 /**


### PR DESCRIPTION
Currently the [`template_include` filter](https://github.com/roots/acorn/blob/master/src/Acorn/Sage/Concerns/FiltersTemplates.php#L40) sets the view to the template path as a fallback when no view exists. 

This is not actually supported by `Roots/view()` but this patch should fix it although I'm not sure it's the correct way.