### PR TITLE
Small bugfix for unit test

### DIFF
--- a/tests/Unit/Clover/ServiceProviderTest.php
+++ b/tests/Unit/Clover/ServiceProviderTest.php
@@ -38,7 +38,7 @@ class ServiceProviderTest extends TestCase
 
         self::assertContains('dummy-plugin', $this->getViewFactoryFromApp()->getRegisteredNamespaces());
         $paths = $this->getViewFactoryFromApp()->getPathsForNamespace('dummy-plugin');
-        self::assertStringContainsString('acorn/tests/Unit/__fixtures__/plugin/config/../resources/views', $paths[0]);
+        self::assertStringContainsString('tests/Unit/__fixtures__/plugin/config/../resources/views', $paths[0]);
     }
 
     public function testRegisterProvidersFromPluginConfig(): void


### PR DESCRIPTION
The CI is red because I expected a path that is different in CI.

* Remove "acorn" from test string as it is not present in CI pipeline