### PR TITLE
Fix for new @once Blocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
     "illuminate/support": "^7.0",
     "illuminate/view": "^7.0",
     "league/flysystem": "^1.0",
+    "ramsey/uuid": "^3.7|^4.0",
     "roots/support": "dev-master",
     "symfony/error-handler": "^5.0",
     "symfony/var-dumper": "^5.0"


### PR DESCRIPTION
Using the new [@once Blocks](https://github.com/laravel/framework/pull/33812) currently fails, since the required library for UUIDs is missing.