### PR TITLE
Capture request as instance in application.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ phpunit.xml
 /composer.lock
 /coverage
 /vendor
+/.idea

--- a/src/Acorn/Bootloader.php
+++ b/src/Acorn/Bootloader.php
@@ -140,6 +140,7 @@ class Bootloader
     protected function bootstrap(): array
     {
         $bootstrap = [
+            \Roots\Acorn\Bootstrap\CaptureRequest::class,
             \Roots\Acorn\Bootstrap\SageFeatures::class,
             \Roots\Acorn\Bootstrap\LoadConfiguration::class,
             \Roots\Acorn\Bootstrap\HandleExceptions::class,

--- a/src/Acorn/Bootstrap/CaptureRequest.php
+++ b/src/Acorn/Bootstrap/CaptureRequest.php
@@ -15,7 +15,7 @@ class CaptureRequest
      */
     public function bootstrap(Application $app)
     {
-    	$app->instance('request', \Illuminate\Http\Request::capture());
-	    Facade::clearResolvedInstance('request');
+        $app->instance('request', \Illuminate\Http\Request::capture());
+        Facade::clearResolvedInstance('request');
     }
 }

--- a/src/Acorn/Bootstrap/CaptureRequest.php
+++ b/src/Acorn/Bootstrap/CaptureRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Roots\Acorn\Bootstrap;
+
+use Illuminate\Support\Facades\Facade;
+use Roots\Acorn\Application;
+
+class CaptureRequest
+{
+    /**
+     * Bootstrap the given application.
+     *
+     * @param \Roots\Acorn\Application $app
+     * @return void
+     */
+    public function bootstrap(Application $app)
+    {
+    	$app->instance('request', \Illuminate\Http\Request::capture());
+	    Facade::clearResolvedInstance('request');
+    }
+}


### PR DESCRIPTION
When Laravel application handles request in Kernel, before send it through router and middlewares [save captured request as instance in application.](https://github.com/laravel/framework/blob/e5b86f2efec2959fb0e85ad5ee5de18f430643c4/src/Illuminate/Foundation/Http/Kernel.php#L130) Acorn do not do it and I have decided to change it  :)

I decide to save captured request as instance in application on bootstrap of course. I create bootstrap class and add it to bootstrap classes array.

**Why this is important?**
Acorn app right know does not know what is request and it dependecy injection is impossibile, also request is base element of HTTP and web applications, it is required to have knowledge about it in our application.