### PR TITLE
Version constraint for `roots/support`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "illuminate/view": "^7.0",
     "league/flysystem": "^1.0",
     "ramsey/uuid": "^3.7|^4.0",
-    "roots/support": "dev-master",
+    "roots/support": "^1.0",
     "symfony/error-handler": "^5.0",
     "symfony/var-dumper": "^5.0"
   },


### PR DESCRIPTION
Helps keeping good `minimum-stability` and things stable.
Using https://github.com/roots/support/releases/tag/1.0.0

💌 