### PR TITLE
Add support for Multisite to acorn commands

### DIFF
--- a/src/Acorn/Console/Commands/Command.php
+++ b/src/Acorn/Console/Commands/Command.php
@@ -3,6 +3,10 @@
 namespace Roots\Acorn\Console\Commands;
 
 use Illuminate\Console\Command as CommandBase;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Illuminate\Console\Parser;
 
 abstract class Command extends CommandBase
 {
@@ -24,5 +28,51 @@ abstract class Command extends CommandBase
     public function setLaravel($laravel)
     {
         parent::setLaravel($this->app = $laravel);
+    }
+    
+    /**
+     * Configure the console command using a fluent definition.
+     *
+     * @return void
+     */
+    protected function configureUsingFluentDefinition()
+    {
+        [$name, $arguments, $options] = Parser::parse($this->signature);
+        
+        // Add option --wp-blog to all signatures
+        $options[] = new InputOption(
+            'wp-blog',
+            null, // shortcut
+            InputOption::VALUE_OPTIONAL,
+            'For multsite environments, either a Blog ID or Blog Domain to switch to before execution',
+            null // default
+        );
+
+        parent::__construct($this->name = $name);
+
+        // After parsing the signature we will spin through the arguments and options
+        // and set them on this command. These will already be changed into proper
+        // instances of these "InputArgument" and "InputOption" Symfony classes.
+        $this->getDefinition()->addArguments($arguments);
+        $this->getDefinition()->addOptions($options);
+    }
+    
+    /**
+     * Execute the console command.
+     *
+     * @param  \Symfony\Component\Console\Input\InputInterface  $input
+     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->hasOption('wp-blog')) {
+            $blog = $input->getOption('wp-blog');
+            if (!is_numeric($blog)) {
+                $blog = get_blog_id_from_url($blog);   
+            }
+            switch_to_blog($blog);
+        }
+        return (int) $this->laravel->call([$this, 'handle']);
     }
 }

--- a/src/Acorn/Console/Commands/Command.php
+++ b/src/Acorn/Console/Commands/Command.php
@@ -4,6 +4,7 @@ namespace Roots\Acorn\Console\Commands;
 
 use Illuminate\Console\Command as CommandBase;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Illuminate\Console\Parser;
@@ -48,7 +49,13 @@ abstract class Command extends CommandBase
             null // default
         );
 
-        parent::__construct($this->name = $name);
+        $this->setDefinition(new InputDefinition());
+
+        if (null !== $name || null !== $name = static::getDefaultName()) {
+            $this->setName($name);
+        }
+
+        $this->configure();
 
         // After parsing the signature we will spin through the arguments and options
         // and set them on this command. These will already be changed into proper


### PR DESCRIPTION
To support multisite, WP-CLI includes a `--url` option. Unfortunately, because acorn executes inside WP-CLI, throwing the `--url` option into a request gets parsed as part of the Laravel command signature and will cause any command that does not include a `--url` option to fail.

My pull request proposes a solution: adding a `--wp-blog` option to all commands executed by acorn. The option is parsed as either a specific Blog ID or a Blog Domain from which the ID can be derived (using `get_blog_id_by_domain($domain)`). Ultimately, the ID is passed to `switch_to_blog($id)`.

My reason for naming the option `--wp-blog` is because some namespacing seems in order. This both ensures that WP-CLI doesn't try to switch the blog itself and allows for commands to use `--url` if they are so designed (it is a fairly generic name for a command-line option).

Alternatively but not without conflicts, this same framework could be used to add `--url` to all commands executed by acorn. That way, WP-CLI would detect that argument and switch blog before acorn is executed. The benefits here would be that anything up-stack from acorn would have the correct blog selected. 