### PR TITLE
Solves #90 (usort returning boolean deprecated)

### DIFF
--- a/src/Roots/Acorn/Console/Commands/SummaryCommand.php
+++ b/src/Roots/Acorn/Console/Commands/SummaryCommand.php
@@ -113,7 +113,7 @@ class SummaryCommand extends ListCommand
             $commands = $commands->toArray();
 
             usort($commands, function ($a, $b) {
-                return $a->getName() > $b->getName();
+                return $a->getName() > $b->getName() ? 1 : -1;
             });
 
             foreach ($commands as $command) {


### PR DESCRIPTION
when running `wp acorn list`:

```
In SummaryCommand.php line 117:
                                                                                                                               
  usort(): Returning bool from comparison function is deprecated, return an integer less than, equal to, or greater than zero
```