### PR TITLE
feat(app-boot): silently fail when provider cannot boot

### DIFF
--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -331,7 +331,7 @@ class Application extends FoundationApplication
         $packages = $this->make(PackageManifest::class)->getManifest();
 
         $message = [
-            BindingResolutionException::class => "Skipping provider [:provider:] because it requires a dependency that does not exist.",
+            BindingResolutionException::class => "Skipping provider [:provider:] because it requires a dependency that cannot be found.",
         ][get_class($e)] ?? "Skipping provider [:provider:] because it encountered an error.";
 
         $providerName = get_class($provider);
@@ -339,7 +339,8 @@ class Application extends FoundationApplication
         $context = [
             'package' => '',
             'provider' => $providerName,
-            'error' => $e->getMessage()
+            'error' => $e->getMessage(),
+            'help' => 'https://roots.io/docs/acorn/troubleshooting'
         ];
 
         foreach ($packages as $package => $configuration) {
@@ -361,7 +362,6 @@ class Application extends FoundationApplication
             ]),
             $context
         );
-        $this->make('log')->info("See https://roots.io/docs/acorn/troubleshooting");
     }
 
     /**

--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -331,8 +331,8 @@ class Application extends FoundationApplication
         $packages = $this->make(PackageManifest::class)->getManifest();
 
         $message = [
-            BindingResolutionException::class => "Skipping provider [:package/provider:] because it requires a dependency that does not exist.",
-        ][get_class($e)] ?? "Skipping provider [:package/provider:] because it encountered an error.";
+            BindingResolutionException::class => "Skipping provider [:provider:] because it requires a dependency that does not exist.",
+        ][get_class($e)] ?? "Skipping provider [:provider:] because it encountered an error.";
 
         $providerName = get_class($provider);
 
@@ -355,8 +355,7 @@ class Application extends FoundationApplication
 
         $this->make('log')->warning(
             strtr($message, [
-                ':package/provider:' => empty($context['package']) ? $context['provider'] : $context['package'],
-                ':package:' => $context['package'] ?? '',
+                ':package:' => $context['package'],
                 ':provider:' => $context['provider'],
                 ':error:' => $context['error']
             ]),

--- a/src/Roots/Acorn/PackageManifest.php
+++ b/src/Roots/Acorn/PackageManifest.php
@@ -30,6 +30,16 @@ class PackageManifest extends FoundationPackageManifest
     }
 
     /**
+     * Get the current package manifest.
+     *
+     * @return array
+     */
+    public function getManifest()
+    {
+        return parent::getManifest();
+    }
+
+    /**
      * Build the manifest and write it to disk.
      *
      * @return void

--- a/src/Roots/Acorn/PackageManifest.php
+++ b/src/Roots/Acorn/PackageManifest.php
@@ -36,25 +36,30 @@ class PackageManifest extends FoundationPackageManifest
      */
     public function build()
     {
-        $packages = [];
+        $packages = array_reduce($this->composerPaths, function ($all, $path) {
+            $packages = [];
 
-        foreach ($this->composerPaths as $path) {
             if ($this->files->exists($path)) {
                 $installed = json_decode($this->files->get($path), true);
 
-                $packages = array_merge($packages, $installed['packages'] ?? $installed);
+                $packages = $installed['packages'] ?? $installed;
             }
-        }
 
-        $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());
+            $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());
 
-        $this->write(collect($packages)->mapWithKeys(function ($package) {
-            return [$this->format($package['name']) => $package['extra']['acorn'] ?? []];
-        })->each(function ($configuration) use (&$ignore) {
-            $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
-        })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
-            return $ignoreAll || in_array($package, $ignore);
-        })->filter()->all());
+            return collect($packages)->mapWithKeys(function ($package) use ($path) {
+                return [
+                    $this->format($package['name'], dirname($path, 2)) =>
+                        $package['extra']['acorn'] ?? $package['extra']['laravel'] ?? []
+                ];
+            })->each(function ($configuration) use (&$ignore) {
+                $ignore = array_merge($ignore, $configuration['dont-discover'] ?? []);
+            })->reject(function ($configuration, $package) use ($ignore, $ignoreAll) {
+                return $ignoreAll || in_array($package, $ignore);
+            })->filter()->merge($all)->all();
+        }, []);
+
+        $this->write($packages);
     }
 
     /**
@@ -66,7 +71,7 @@ class PackageManifest extends FoundationPackageManifest
      */
     protected function format($package, $vendorPath = null)
     {
-        return str_replace($this->vendorPath . '/', '', $package);
+        return str_replace($vendorPath . '/', '', $package);
     }
 
     /**
@@ -76,19 +81,18 @@ class PackageManifest extends FoundationPackageManifest
      */
     protected function packagesToIgnore()
     {
-        $ignore = [];
-
-        foreach ($this->composerPaths as $path) {
+        return array_reduce($this->composerPaths, function ($ignore, $path) {
             if (! $this->files->exists($path)) {
-                continue;
+                return $ignore;
             }
 
-            $ignore = array_merge($ignore, json_decode(
-                $this->files->get($path),
-                true
-            )['extra']['laravel']['dont-discover'] ?? []);
-        }
+            $package = json_decode($this->files->get($path), true);
 
-        return $ignore;
+            return array_merge(
+                $ignore,
+                $package['extra']['laravel']['dont-discover'] ?? [],
+                $package['extra']['acorn']['dont-discover'] ?? []
+            );
+        }, []);
     }
 }


### PR DESCRIPTION
This functionality should probably be extracted into its own class or trait, but for now it's just a chonky method.

Here is an example of how it looks in the logs.

```log
[2021-02-26 22:56:13] development.WARNING: Skipping provider [Propaganistas\LaravelPhone\PhoneServiceProvider] because it requires a dependency that does not exist. {"package":"propaganistas/laravel-phone","provider":"Propaganistas\\LaravelPhone\\PhoneServiceProvider","error":"Target class [validator] does not exist.","help":"https://roots.io/docs/acorn/troubleshooting"}
```