### PR TITLE
fix(console): support wp-cli global parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
     "spatie/pest-plugin-snapshots": "^1.0",
     "spatie/temporary-directory": "^1.3",
     "squizlabs/php_codesniffer": "^3.5",
-    "tmarsteel/mockery-callable-mock": "^2.1"
+    "tmarsteel/mockery-callable-mock": "^2.1",
+    "wp-cli/wp-cli": "^2.5"
   },
   "suggest": {
     "filp/whoops": "Required for friendly error pages in development (^2.9).",


### PR DESCRIPTION
Undecided whether we want to go this route in particular.

This requires more testing.


Closes #81
Closes #48