### PR TITLE
build(deps-dev): revert spatie/temporary-directory requirement from ^2.0" to ^1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
     "phpcompatibility/php-compatibility": "^9.3",
     "roave/security-advisories": "dev-master",
     "spatie/pest-plugin-snapshots": "^1.0",
-    "spatie/temporary-directory": "^2.0",
+    "spatie/temporary-directory": "^1.3",
     "squizlabs/php_codesniffer": "^3.5"
   },
   "suggest": {


### PR DESCRIPTION
I don't see a reason to upgrade this yet, especially since it requires PHP 8 now.

Reverts roots/acorn#97