### PR TITLE
feat(sage): add privacypolicy and embed filters

### DIFF
--- a/src/Roots/Acorn/Sage/SageServiceProvider.php
+++ b/src/Roots/Acorn/Sage/SageServiceProvider.php
@@ -67,6 +67,8 @@ class SageServiceProvider extends ServiceProvider
             'single_template_hierarchy',
             'singular_template_hierarchy',
             'attachment_template_hierarchy',
+            'privacypolicy_template_hierarchy',
+            'embed_template_hierarchy',
         ], $sage->filter('template_hierarchy'), 10);
     }
 


### PR DESCRIPTION
Add missing `privacypolicy_template_hierarchy` and `embed_template_hierarchy` to filter.

I found that `privacy-policy.blade.php` didn't load, this fixes it.

Reference:
https://github.com/WordPress/WordPress/blob/master/wp-includes/template.php#L37-L62