### PR TITLE
Update VendorPublishCommand.php

### DIFF
--- a/src/Illuminate/Foundation/Console/VendorPublishCommand.php
+++ b/src/Illuminate/Foundation/Console/VendorPublishCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Support\ServiceProvider;
 use League\Flysystem\Adapter\Local as LocalAdapter;
 use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\MountManager;
+use function Roots\base_path;
 
 class VendorPublishCommand extends Command
 {


### PR DESCRIPTION
Corrected an error when publish (wp acorn vendor:publish) throw an error : base_path is undefined