### PR TITLE
fix(config-view): use commented example directive

### DIFF
--- a/config/view.php
+++ b/config/view.php
@@ -79,6 +79,6 @@ return [
     */
 
     'directives' => [
-        'asset'  => Roots\Acorn\Assets\View\BladeDirective::class,
+        // 'foo'  => App\View\FooDirective::class,
     ],
 ];

--- a/config/view.php
+++ b/config/view.php
@@ -79,6 +79,6 @@ return [
     */
 
     'directives' => [
-        'asset'  => Roots\Acorn\Assets\AssetDirective::class,
+        'asset'  => Roots\Acorn\Assets\View\BladeDirective::class,
     ],
 ];


### PR DESCRIPTION
Apparently the `AssetDirective` was renamed/moved to  `Roots\Acorn\Assets\View\BladeDirective`.
With the wrong directive defined, Acorn 2.0.0-alpha.0 doesn't register View Composers and throws an error for a missing var.