### PR TITLE
fix(exception-handler): Symfony error handler not rendering

### DIFF
--- a/src/Roots/Acorn/Bootstrap/HandleExceptions.php
+++ b/src/Roots/Acorn/Bootstrap/HandleExceptions.php
@@ -43,6 +43,7 @@ class HandleExceptions extends FoundationHandleExceptionsBootstrapper
      */
     protected function renderHttpResponse(Throwable $e)
     {
-        $this->getExceptionHandler()->render('', $e);
+        ob_clean();
+        $this->getExceptionHandler()->render('', $e)->send();
     }
 }

--- a/src/Roots/Acorn/Exceptions/Handler.php
+++ b/src/Roots/Acorn/Exceptions/Handler.php
@@ -23,13 +23,24 @@ class Handler extends FoundationHandler
      * @throws \Throwable
      */
     public function render($request, Throwable $e)
-    {        
+    {
+        return $this->convertExceptionToResponse($e);
+    }
+
+    /**
+     * Get the response content for the given exception.
+     *
+     * @param  \Throwable  $e
+     * @return string
+     */
+    protected function renderExceptionContent(Throwable $e)
+    {
         try {
-            echo app()->environment('development') && class_exists(Whoops::class)
+            return app()->environment('development') && class_exists(Whoops::class)
                         ? $this->renderExceptionWithWhoops($e)
                         : $this->renderExceptionWithSymfony($e, app()->environment('development'));
         } catch (Exception $e) {
-            echo $this->renderExceptionWithSymfony($e, app()->environment('development'));
+            return $this->renderExceptionWithSymfony($e, app()->environment('development'));
         }
     }
 

--- a/src/Roots/Acorn/Exceptions/Handler.php
+++ b/src/Roots/Acorn/Exceptions/Handler.php
@@ -25,11 +25,11 @@ class Handler extends FoundationHandler
     public function render($request, Throwable $e)
     {
         try {
-            return app()->environment('development') && class_exists(Whoops::class)
+            echo app()->environment('development') && class_exists(Whoops::class)
                         ? $this->renderExceptionWithWhoops($e)
                         : $this->renderExceptionWithSymfony($e, app()->environment('development'));
         } catch (Exception $e) {
-            return $this->renderExceptionWithSymfony($e, app()->environment('development'));
+            echo $this->renderExceptionWithSymfony($e, app()->environment('development'));
         }
     }
 
@@ -43,7 +43,7 @@ class Handler extends FoundationHandler
     {
         return tap(new Whoops(), function ($whoops) {
             $whoops->appendHandler($this->whoopsHandler());
-
+            $whoops->writeToOutput(false);
             $whoops->allowQuit(false);
         })->handleException($e);
     }

--- a/src/Roots/Acorn/Exceptions/Handler.php
+++ b/src/Roots/Acorn/Exceptions/Handler.php
@@ -23,7 +23,7 @@ class Handler extends FoundationHandler
      * @throws \Throwable
      */
     public function render($request, Throwable $e)
-    {
+    {        
         try {
             echo app()->environment('development') && class_exists(Whoops::class)
                         ? $this->renderExceptionWithWhoops($e)
@@ -31,21 +31,6 @@ class Handler extends FoundationHandler
         } catch (Exception $e) {
             echo $this->renderExceptionWithSymfony($e, app()->environment('development'));
         }
-    }
-
-    /**
-     * Render an exception to a string using "Whoops".
-     *
-     * @param  Throwable  $e
-     * @return string
-     */
-    protected function renderExceptionWithWhoops(Throwable $e)
-    {
-        return tap(new Whoops(), function ($whoops) {
-            $whoops->appendHandler($this->whoopsHandler());
-            $whoops->writeToOutput(false);
-            $whoops->allowQuit(false);
-        })->handleException($e);
     }
 
     /**


### PR DESCRIPTION
This PR fixes [Issue 109](https://github.com/roots/acorn/issues/109) which returns a blank page instead of the symfony error handler.

The issue is: While Whoops writes directly to the output, the symfony handler is only returning the HTML and thus not rendering at all. I reverted the custom Whoops handler and added an `echo` statement.