### PR TITLE
feat(exception-handler): Enable Whoops handler for "local" environment

### DIFF
--- a/src/Roots/Acorn/Exceptions/Handler.php
+++ b/src/Roots/Acorn/Exceptions/Handler.php
@@ -25,7 +25,7 @@ class Handler extends FoundationHandler
     public function render($request, Throwable $e)
     {
         try {
-            return app()->environment('development') && class_exists(Whoops::class)
+            return app()->environment(['development', 'local']) && class_exists(Whoops::class)
                         ? $this->renderExceptionWithWhoops($e)
                         : $this->renderExceptionWithSymfony($e, app()->environment('development'));
         } catch (Exception $e) {


### PR DESCRIPTION
I guess it's safe to use Whoops for "local" environments ;)