### PR TITLE
fix(error-handler): continue handling errors when not throwing

### DIFF
--- a/src/Roots/Acorn/Bootstrap/HandleExceptions.php
+++ b/src/Roots/Acorn/Bootstrap/HandleExceptions.php
@@ -42,7 +42,7 @@ class HandleExceptions extends FoundationHandleExceptionsBootstrapper
      * @param  string  $file
      * @param  int  $line
      * @param  array  $context
-     * @return void
+     * @return void|false
      *
      * @throws \ErrorException
      */
@@ -51,9 +51,11 @@ class HandleExceptions extends FoundationHandleExceptionsBootstrapper
         try {
             parent::handleError($level, $message, $file, $line, $context);
         } catch (Throwable $e) {
-            if (apply_filters('acorn/throw_error_exception', true, $e)) {
-                throw $e;
+            if (! apply_filters('acorn/throw_error_exception', true, $e)) {
+                return false;
             }
+
+            throw $e;
         }
     }
 


### PR DESCRIPTION
`return false` when user chooses to not throw an exception

this allows other error handlers to continue handling the error

this is currently untested

closes #128