### PR TITLE
fix(boot-exceptions): remove side effects

### DIFF
--- a/src/Roots/Acorn/Bootstrap/HandleExceptions.php
+++ b/src/Roots/Acorn/Bootstrap/HandleExceptions.php
@@ -31,7 +31,9 @@ class HandleExceptions extends FoundationHandleExceptionsBootstrapper
             \Roots\Acorn\Exceptions\Handler::class
         );
 
-        parent::bootstrap($app);
+        set_error_handler([$this, 'handleError']);
+        set_exception_handler([$this, 'handleException']);
+        register_shutdown_function([$this, 'handleShutdown']);
     }
 
     /**


### PR DESCRIPTION
parent method sets `display_errors` and `error_reporting()`

this pr lets wordpress handle setting those by not calling the parent method

this is currently untested

closes #130