### PR TITLE
fix(exception-handler): clean output buffer

### DIFF
--- a/src/Roots/Acorn/Bootstrap/HandleExceptions.php
+++ b/src/Roots/Acorn/Bootstrap/HandleExceptions.php
@@ -77,4 +77,16 @@ class HandleExceptions extends FoundationHandleExceptionsBootstrapper
         return !$this->app->runningInConsole()
             && is_readable(WP_CONTENT_DIR . '/fatal-error-handler.php');
     }
+
+    /**
+     * Render an exception as an HTTP response and send it.
+     *
+     * @param  \Throwable  $e
+     * @return void
+     */
+    protected function renderHttpResponse(Throwable $e)
+    {
+        ob_end_clean();
+        parent::renderHttpResponse($e);
+    }
 }


### PR DESCRIPTION
this cleans the output buffer before rendering the http response

this is currently untested

closes #129