### PR TITLE
Allow Acorn to be installed at a different path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "roots/acorn",
+  "type": "wordpress-muplugin",
   "license": "MIT",
   "description": "Framework for Roots WordPress projects built with Laravel components.",
   "homepage": "https://roots.io/acorn/",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "php": "^7.3|^8.0",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "composer/installers": "^2.0",
+    "composer/installers": "^1.12",
     "illuminate/cache": "^8.0",
     "illuminate/config": "^8.0",
     "illuminate/console": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "roots/acorn",
-  "type": "wordpress-muplugin",
+  "type": "library",
   "license": "MIT",
   "description": "Framework for Roots WordPress projects built with Laravel components.",
   "homepage": "https://roots.io/acorn/",

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     "php": "^7.3|^8.0",
     "ext-json": "*",
     "ext-mbstring": "*",
+    "composer/installers": "^2.0",
     "illuminate/cache": "^8.0",
     "illuminate/config": "^8.0",
     "illuminate/console": "^8.0",


### PR DESCRIPTION
From what I gather, this needs to be installed so Acorn can be installed as a plugin or must-use plugin by adding the package to the `extra.installer-paths` config option in Bedrock’s `composer.json` like this:

```json
  "extra": {
    "installer-paths": {
      "web/app/mu-plugins/{$name}/": ["roots/acorn", "type:wordpress-muplugin"],
      "web/app/plugins/{$name}/": ["type:wordpress-plugin"],
      "web/app/themes/{$name}/": ["type:wordpress-theme"]
    },
    "wordpress-install-dir": "web/wp"
  },
```

[From the Composer docs about `installer-paths`](https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md):

> Note: You cannot use this to change the path of any package. This is only applicable to packages that require composer/installers and use a custom type that it handles.


