### PR TITLE
fix(wp-cli): support `--args`

### DIFF
--- a/src/Roots/Acorn/Bootstrap/RegisterConsole.php
+++ b/src/Roots/Acorn/Bootstrap/RegisterConsole.php
@@ -40,7 +40,11 @@ class RegisterConsole
             $command = implode(' ', $args);
 
             foreach ($assoc_args as $key => $value) {
-                $command .= "--{$key}='{$value}'";
+                $command .= " --{$key}";
+
+                if ($value !== true) {
+                    $command .= "='{$value}'";
+                }
             }
 
             $status = $kernel->handle($input = new StringInput($command), new ConsoleOutput());


### PR DESCRIPTION
Currently when you add `--some-argument` to a wp-cli command, it doesn't add a space, and it adds `=1` to truthy options.

Below is an example of what gets passed to the Console instance.

Input.
```wp acorn make:component Kjo --force``` 

Expected.
```make:component Kjo --force```

Actual.
```make:component Kjo--force='1'```

This PR fixes this behavior