### PR TITLE
fix(app-aliases): use roots namespace for acorn aliases

### DIFF
--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -271,10 +271,10 @@ class Application extends FoundationApplication
 
         $aliases = [
             'app'             => self::class,
-            'assets.manifest' => \Acorn\Assets\Manifest::class,
-            'config'          => \Acorn\Config::class,
-            'files'           => \Acorn\Filesystem\Filesystem::class,
-            'view.finder'     => \Acorn\View\FileViewFinder::class,
+            'assets.manifest' => \Roots\Acorn\Assets\Manifest::class,
+            'config'          => \Roots\Acorn\Config::class,
+            'files'           => \Roots\Acorn\Filesystem\Filesystem::class,
+            'view.finder'     => \Roots\Acorn\View\FileViewFinder::class,
             \Illuminate\Foundation\PackageManifest::class => \Roots\Acorn\PackageManifest::class,
         ];
 

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -208,3 +208,14 @@ it('gracefully skips a provider that does not exist', function () {
 
     $app->boot();
 });
+
+it('uses custom aliases', function () {
+    $app = new Application();
+
+    expect($app->getAlias(\Roots\Acorn\Application::class))->toBe('app');
+    expect($app->getAlias(\Roots\Acorn\Assets\Manifest::class))->toBe('assets.manifest');
+    expect($app->getAlias(\Roots\Acorn\Config::class))->toBe('config');
+    expect($app->getAlias(\Roots\Acorn\Filesystem\Filesystem::class))->toBe('files');
+    expect($app->getAlias(\Roots\Acorn\View\FileViewFinder::class))->toBe('view.finder');
+    expect($app->getAlias(\Roots\Acorn\PackageManifest::class))->toBe(\Illuminate\Foundation\PackageManifest::class);
+});


### PR DESCRIPTION
Oops! 🙈

Closes #142 