### PR TITLE
fix(exception-handler): сheck buffer before clean

### DIFF
--- a/src/Roots/Acorn/Bootstrap/HandleExceptions.php
+++ b/src/Roots/Acorn/Bootstrap/HandleExceptions.php
@@ -90,9 +90,9 @@ class HandleExceptions extends FoundationHandleExceptionsBootstrapper
      */
     protected function renderHttpResponse(Throwable $e)
     {
-        if (ob_get_contents()) {
+        if (ob_get_length()) {
             ob_end_clean();
-        };
+        }
 
         parent::renderHttpResponse($e);
     }

--- a/src/Roots/Acorn/Bootstrap/HandleExceptions.php
+++ b/src/Roots/Acorn/Bootstrap/HandleExceptions.php
@@ -90,7 +90,10 @@ class HandleExceptions extends FoundationHandleExceptionsBootstrapper
      */
     protected function renderHttpResponse(Throwable $e)
     {
-        ob_end_clean();
+        if (ob_get_contents()) {
+            ob_end_clean();
+        };
+
         parent::renderHttpResponse($e);
     }
 }


### PR DESCRIPTION
* I have a clean Sage 10 theme installed.

When starting 'yarn dev' development, I deliberately make a mistake in the code to go into debug mode and the error appears.

```
Fatal error: Uncaught ErrorException: ob_end_clean(): Failed to delete buffer. No buffer to delete in /srv/www/test.com/current/web/app/themes/sage/vendor/roots/acorn/src/Roots/Acorn/Bootstrap/HandleExceptions.php:93 Stack trace: #0 /srv/www/test.com/current/web/app/themes/sage/vendor/roots/acorn/src/Roots/Acorn/Bootstrap/HandleExceptions.php(54): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(8, 'ob_end_clean():...', '/srv/www/test.c...', 93, Array) #1 [internal function]: Roots\Acorn\Bootstrap\HandleExceptions->handleError(8, 'ob_end_clean():...', '/srv/www/test.c...', 93) #2 /srv/www/test.com/current/web/app/themes/sage/vendor/roots/acorn/src/Roots/Acorn/Bootstrap/HandleExceptions.php(93): ob_end_clean() #3 /srv/www/test.com/current/web/app/themes/sage/vendor/roots/acorn/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(144): Roots\Acorn\Bootstrap\HandleExceptions->renderHttpResponse(Object(InvalidArgumentException)) #4 [internal function]: Illuminate\Foundation\Bootstrap\HandleExceptions->handleException(Object(InvalidArgumentException)) #5 {main} thrown in /srv/www/test.com/current/web/app/themes/sage/vendor/roots/acorn/src/Roots/Acorn/Bootstrap/HandleExceptions.php on line 93
```

As I understand it, the ob_end_clean () function needs to check if there is something in the buffer.

After adding the code, I immediately turn on the debug mode, if there are errors.