### PR TITLE
fix(assets): throw exception when manifest is missing

### DIFF
--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -120,7 +120,7 @@ class Application extends FoundationApplication
                 throw new Exception("The {$path_type} path type is not supported.");
             }
 
-            if (! is_dir($path) || ! is_readable($path)) {
+            if ($path_type !== 'public' && (! is_dir($path) || ! is_readable($path))) {
                 throw new Exception("The {$path} directory must be present.");
             }
 

--- a/src/Roots/Acorn/Assets/Contracts/ManifestNotFoundException.php
+++ b/src/Roots/Acorn/Assets/Contracts/ManifestNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Roots\Acorn\Assets\Contracts;
+
+use Exception;
+
+class ManifestNotFoundException extends Exception
+{
+    //
+}

--- a/src/Roots/Acorn/Assets/Manager.php
+++ b/src/Roots/Acorn/Assets/Manager.php
@@ -5,6 +5,7 @@ namespace Roots\Acorn\Assets;
 use InvalidArgumentException;
 use Roots\Acorn\Assets\Concerns\Mixable;
 use Roots\Acorn\Assets\Contracts\Manifest as ManifestContract;
+use Roots\Acorn\Assets\Contracts\ManifestNotFoundException;
 
 /**
  * Manage assets manifests
@@ -99,7 +100,11 @@ class Manager
      */
     protected function getJsonManifest(string $jsonManifest): array
     {
-        return file_exists($jsonManifest) ? json_decode(file_get_contents($jsonManifest), true) : [];
+        if (! file_exists($jsonManifest)) {
+            throw new ManifestNotFoundException("The manifest [{$jsonManifest}] cannot be found.");
+        }
+
+        return json_decode(file_get_contents($jsonManifest), true) ?? [];
     }
 
     /**

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -38,6 +38,15 @@ it('rejects invalid custom paths', function () {
     ]);
 })->throws(Exception::class);
 
+it('allows invalid public path', function () {
+    $app = new Application();
+
+    $app->usePaths([
+        'app' => $this->fixture('use_paths/app'),
+        'public' => __DIR__ . '/this/does/not/exist',
+    ]);
+})->not->throws(Exception::class);
+
 it('accepts an array of custom paths', function () {
     $app = new Application(temp('base_path'));
 

--- a/tests/Assets/ManagerTest.php
+++ b/tests/Assets/ManagerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Roots\Acorn\Assets\Contracts\Manifest as ManifestContract;
+use Roots\Acorn\Assets\Contracts\ManifestNotFoundException;
 use Roots\Acorn\Assets\Manager;
 use Roots\Acorn\Assets\Manifest;
 use Roots\Acorn\Tests\Test\TestCase;
@@ -33,6 +34,20 @@ it('registers a manifest', function () {
     expect($assets->manifest('theme'))->toBeInstanceOf(ManifestContract::class);
 });
 
+it('throws an error if an assets manifest does not exist', function () {
+    $assets = new Manager([
+        'manifests' => [
+            'theme' => [
+                'path' => $this->fixture('bud_single_runtime'),
+                'url' => 'https://k.jo',
+                'assets' => __DIR__ . '/does/not/exist/manifest.json',
+            ]
+        ]
+    ]);
+
+    $assets->manifest('theme')->asset('app.css')->uri();
+})->throws(ManifestNotFoundException::class);
+
 it('reads an assets manifest', function () {
     $assets = new Manager([
         'manifests' => [
@@ -47,6 +62,20 @@ it('reads an assets manifest', function () {
     assertMatchesSnapshot($assets->manifest('theme')->asset('app.css')->uri());
     assertMatchesSnapshot($assets->manifest('theme')->asset('app.js')->uri());
 });
+
+it('throws an error if a bundles manifest does not exist', function () {
+    $assets = new Manager([
+        'manifests' => [
+            'theme' => [
+                'path' => $this->fixture('bud_single_runtime'),
+                'url' => 'https://k.jo',
+                'bundles' => __DIR__ . '/does/not/exist/entrypoints.json',
+            ]
+        ]
+    ]);
+
+    $assets->manifest('theme')->bundle('app')->js()->toJson();
+})->throws(ManifestNotFoundException::class);
 
 it('reads a bundles manifest', function () {
     $assets = new Manager([


### PR DESCRIPTION
Now when a manifest is missing, users will still be able to use the admin panel and activate their theme, but the frontend will display a page informing them that the manifest is missing.