### PR TITLE
chore(config-assets): default path `<sage>/public`

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -32,8 +32,8 @@ return [
 
     'manifests' => [
         'theme' => [
-            'path' => get_theme_file_path(),
-            'url' => get_theme_file_uri(),
+            'path' => get_theme_file_path('public'),
+            'url' => get_theme_file_uri('public'),
             'assets' => public_path('manifest.json'),
             'bundles' => public_path('entrypoints.json'),
         ]


### PR DESCRIPTION
Previous config default was for Sage with Laravel Mix.

This config should work with Bud.