### PR TITLE
fix(composer): use wp-cli to clear compiled

### DIFF
--- a/src/Roots/Acorn/ComposerScripts.php
+++ b/src/Roots/Acorn/ComposerScripts.php
@@ -3,6 +3,8 @@
 namespace Roots\Acorn;
 
 use Illuminate\Foundation\ComposerScripts as FoundationComposerScripts;
+use Roots\Acorn\Console\Console;
+use Roots\Acorn\Filesystem\Filesystem;
 
 class ComposerScripts extends FoundationComposerScripts
 {
@@ -13,14 +15,9 @@ class ComposerScripts extends FoundationComposerScripts
      */
     protected static function clearCompiled()
     {
-        $laravel = new Application(getcwd());
+        $console = new Console(new Filesystem, getcwd());
 
-        if (is_file($servicesPath = $laravel->getCachedServicesPath())) {
-            @unlink($servicesPath);
-        }
-
-        if (is_file($packagesPath = $laravel->getCachedPackagesPath())) {
-            @unlink($packagesPath);
-        }
+        $console->configClear();
+        $console->clearCompiled();
     }
 }

--- a/src/Roots/Acorn/ComposerScripts.php
+++ b/src/Roots/Acorn/ComposerScripts.php
@@ -15,7 +15,7 @@ class ComposerScripts extends FoundationComposerScripts
      */
     protected static function clearCompiled()
     {
-        $console = new Console(new Filesystem, getcwd());
+        $console = new Console(new Filesystem(), getcwd());
 
         $console->configClear();
         $console->clearCompiled();

--- a/src/Roots/Acorn/Console/Console.php
+++ b/src/Roots/Acorn/Console/Console.php
@@ -7,106 +7,106 @@ use Illuminate\Support\Composer;
 class Console extends Composer
 {
     /**
+     * Execute acorn clear-compiled command.
+     *
+     * @return int
+     */
+    public function clearCompiled(): int
+    {
+        return $this->acorn('clear-compiled');
+    }
+
+    /**
      * Execute acorn config:cache command.
      *
-     * @return void
+     * @return int
      */
-    public function configCache()
+    public function configCache(): int
     {
-        $this->acorn('config:cache');
+        return $this->acorn('config:cache');
     }
 
     /**
      * Execute acorn config:clear command.
      *
-     * @return void
+     * @return int
      */
-    public function configClear()
+    public function configClear(): int
     {
-        $this->acorn('config:clear');
+        return $this->acorn('config:clear');
     }
 
     /**
      * Execute acorn optimize command.
      *
-     * @return void
+     * @return int
      */
-    public function optimize()
+    public function optimize(): int
     {
-        $this->acorn('optimize');
+        return $this->acorn('optimize');
     }
 
     /**
      * Execute acorn optimize:clear command.
      *
-     * @return void
+     * @return int
      */
-    public function optimizeClear()
+    public function optimizeClear(): int
     {
-        $this->acorn('optimize:clear');
-    }
-
-    /**
-     * Execute acorn package:clear command.
-     *
-     * @return void
-     */
-    public function packageClear()
-    {
-        $this->acorn('package:clear');
+        return $this->acorn('optimize:clear');
     }
 
     /**
      * Execute acorn package:discover command.
      *
-     * @return void
+     * @return int
      */
-    public function packageDiscover()
+    public function packageDiscover(): int
     {
-        $this->acorn('package:discover');
+        return $this->acorn('package:discover');
     }
 
     /**
      * Execute acorn vendor:public command.
      *
-     * @return void
+     * @return int
      */
-    public function vendorPublish()
+    public function vendorPublish(): int
     {
-        $this->acorn('vendor:publish');
+        return $this->acorn('vendor:publish');
     }
 
     /**
      * Execute acorn view:cache command.
      *
-     * @return void
+     * @return int
      */
-    public function viewCache()
+    public function viewCache(): int
     {
-        $this->acorn('view:cache');
+        return $this->acorn('view:cache');
     }
 
     /**
      * Execute acorn view:clear command.
      *
-     * @return void
+     * @return int
      */
-    public function viewClear()
+    public function viewClear(): int
     {
-        $this->acorn('view:clear');
+        return $this->acorn('view:clear');
     }
 
     /**
      * Execute acorn command.
      *
      * @param  array  $command
-     * @return void
+     * @return int
      */
-    public function acorn($command)
+    public function acorn($command): int
     {
         $command = array_merge($this->findWpCli(), ['acorn'], (array) $command);
 
-        $this->getProcess($command)->run();
+        return $this->getProcess($command)->run();
     }
 
     /**


### PR DESCRIPTION
Currently when Sage attempts to run a [post-dump-autoload script](https://github.com/roots/sage/blob/main/composer.json#L65), it fails due to some changes Acorn has made to the directory structure. Even if those changes were reverted, this implementation is flawed due to the flexibility of Acorn's paths.

This PR will utilize wp-cli to run acorn console commands. This does mean that WordPress gets booted, [which is less than ideal](https://user-images.githubusercontent.com/2104321/147349858-e4a03db0-7c72-42ea-949b-411bad56643b.png), but the risk is minimal.

x-ref [log1x/acf-composer#101](https://github.com/Log1x/acf-composer/issues/101)