### PR TITLE
chore(deps-dev): allow required composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,11 @@
     "filp/whoops": "Required for friendly error pages in development (^2.9)."
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true,


### PR DESCRIPTION
This has zero impact on users. This is strictly for development. We require two composer plugins. [As of Composer v2.2.0, plugins must be explicitly allowed by default](https://getcomposer.org/doc/06-config.md#allow-plugins).

![image](https://user-images.githubusercontent.com/2104321/147351059-34663291-9eb7-455b-bb53-df0e1bca9ffb.png)
