### PR TITLE
fix(console): escape backslashes before sending to kernel

### DIFF
--- a/src/Roots/Acorn/Bootstrap/RegisterConsole.php
+++ b/src/Roots/Acorn/Bootstrap/RegisterConsole.php
@@ -46,6 +46,8 @@ class RegisterConsole
                     $command .= "='{$value}'";
                 }
             }
+            
+            $command = str_replace('\\', '\\\\', $command);
 
             $status = $kernel->handle($input = new StringInput($command), new ConsoleOutput());
 

--- a/src/Roots/Acorn/Bootstrap/RegisterConsole.php
+++ b/src/Roots/Acorn/Bootstrap/RegisterConsole.php
@@ -46,7 +46,7 @@ class RegisterConsole
                     $command .= "='{$value}'";
                 }
             }
-            
+
             $command = str_replace('\\', '\\\\', $command);
 
             $status = $kernel->handle($input = new StringInput($command), new ConsoleOutput());


### PR DESCRIPTION
Backslashes are unescaped prior to sending to console kernel, so we have to re-escape them.