### PR TITLE
🔧 use `get_theme_file_path` for default manifest path

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -34,8 +34,8 @@ return [
         'theme' => [
             'path' => get_theme_file_path('public'),
             'url' => get_theme_file_uri('public'),
-            'assets' => public_path('manifest.json'),
-            'bundles' => public_path('entrypoints.json'),
+            'assets' => get_theme_file_path('public/manifest.json'),
+            'bundles' => get_theme_file_path('public/entrypoints.json'),
         ]
     ]
 ];


### PR DESCRIPTION
This will allow `public` to exist in the base path when the base path is outside of the theme, such as when the base directory is your bedrock root and you use `public` as your web root.