### PR TITLE
🥅 use exception handler to report skipped providers

### DIFF
--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -12,6 +12,7 @@ use Illuminate\Log\LogServiceProvider;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Roots\Acorn\Exceptions\SkipProviderException;
 use Roots\Acorn\Filesystem\Filesystem;
 use RuntimeException;
 use Throwable;
@@ -289,38 +290,6 @@ class Application extends FoundationApplication
     }
 
     /**
-     * Skip booting service provider and log error.
-     *
-     * @param  \Illuminate\Support\ServiceProvider|string  $provider
-     * @param  Throwable $e
-     * @return void
-     */
-    protected function skipProvider($provider, Throwable $e)
-    {
-        $message = [
-            BindingResolutionException::class => "Skipping provider [:provider:] because it requires a dependency that cannot be found.",
-        ][get_class($e)] ?? "Skipping provider [:provider:] because it encountered an error.";
-
-        $provider_name = is_object($provider) ? get_class($provider) : $provider;
-
-        $context = [
-            'package' => $this->make(PackageManifest::class)->getPackage($provider_name),
-            'provider' => $provider_name,
-            'error' => $e->getMessage(),
-            'help' => 'https://roots.io/docs/acorn/troubleshooting'
-        ];
-
-        $this->make('log')->warning(
-            strtr($message, [
-                ':package:' => $context['package'],
-                ':provider:' => $context['provider'],
-                ':error:' => $context['error']
-            ]),
-            $context
-        );
-    }
-
-    /**
      * Register all of the configured providers.
      *
      * @return void
@@ -348,10 +317,41 @@ class Application extends FoundationApplication
     public function register($provider, $force = false)
     {
         try {
-            parent::register($provider, $force);
+            if (is_string($provider) && ! class_exists($provider)) {
+                throw new SkipProviderException("Skipping provider [{$provider}] because it does not exist.");
+            }
+            return parent::register($provider, $force);
         } catch (Throwable $e) {
-            $this->skipProvider($provider, $e);
+            return $this->skipProvider($provider, $e);
         }
+    }
+
+    /**
+     * Skip booting service provider and log error.
+     *
+     * @param  \Illuminate\Support\ServiceProvider|string  $provider
+     * @param  Throwable $e
+     * @return \Illuminate\Support\ServiceProvider
+     */
+    protected function skipProvider($provider, Throwable $e): ServiceProvider
+    {
+        $provider_name = is_object($provider) ? get_class($provider) : $provider;
+
+        if (! $e instanceof SkipProviderException) {
+            $message = [
+                BindingResolutionException::class => "Skipping provider [{$provider_name}] because it requires a dependency that cannot be found.",
+            ][$error = get_class($e)] ?? "Skipping provider [{$provider_name}] because it encountered an error [{$error}].";
+
+            $e = new SkipProviderException($message, 0, $e);
+        }
+
+        if (method_exists($packages = $this->make(PackageManifest::class), 'getPackage')) {
+            $e->setPackage($packages->getPackage($provider_name));
+        }
+
+        report($e);
+
+        return is_object($provider) ? $provider : new class ($this) extends ServiceProvider {};
     }
 
     /**

--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -297,6 +297,7 @@ class Application extends FoundationApplication
     public function registerConfiguredProviders()
     {
         $providers = Collection::make($this->config['app.providers'])
+            ->filter('class_exists')
             ->partition(function ($provider) {
                 return Str::startsWith($provider, ['Illuminate\\', 'Roots\\']);
             });

--- a/src/Roots/Acorn/Exceptions/SkipProviderException.php
+++ b/src/Roots/Acorn/Exceptions/SkipProviderException.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Roots\Acorn\Exceptions;
+
+use InvalidArgumentException;
+use Throwable;
+
+class SkipProviderException extends InvalidArgumentException
+{
+    /**
+     * Create a new exception.
+     *
+     * @param string $message
+     * @param int $code
+     * @param Throwable $previous
+     * @return void
+     */
+    public function __construct(string $message = "", int $code = 0, ?Throwable $previous = null, string $package = '')
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->package = $package;
+    }
+
+
+    /**
+     * Name of the provider's package.
+     *
+     * @var string
+     */
+    protected $package;
+
+    /**
+     * Set the name of the provider's package.
+     *
+     * @param string $package
+     * @return void
+     */
+    public function setPackage(string $package)
+    {
+        $this->package = $package;
+    }
+
+    /**
+     * Get the provider's package.
+     *
+     * @return string
+     */
+    public function package()
+    {
+        return $this->package;
+    }
+
+    /**
+     * Report the exception.
+     *
+     * @return array
+     */
+    public function context()
+    {
+        return [
+            'package' => $this->package()
+        ];
+    }
+}

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -166,11 +166,11 @@ it('boots a provider', function () {
 });
 
 it('gracefully skips a provider that fails to boot', function () {
-    $logger = mock(\Illuminate\Log\LogServiceProvider::class);
+    $handler = mock(\Illuminate\Contracts\Debug\ExceptionHandler::class);
     $manifest = mock(\Roots\Acorn\PackageManifest::class);
     $app = new Application();
 
-    $app->singleton('log', fn () => $logger);
+    $app->singleton(\Illuminate\Contracts\Debug\ExceptionHandler::class, fn () => $handler);
     $app->singleton(\Illuminate\Foundation\PackageManifest::class, fn () => $manifest);
 
     // the core of this test is to make sure that when a class or function is called that
@@ -182,9 +182,9 @@ it('gracefully skips a provider that fails to boot', function () {
         }
     };
 
-    $logger
-        ->shouldReceive('warning')
-        ->withArgs(fn ($message) => expect($message)->toContain('Skipping provider') || true)
+    $handler
+        ->shouldReceive('report')
+        ->withArgs(fn (\Roots\Acorn\Exceptions\SkipProviderException $e) => expect($e->getMessage())->toContain('Skipping provider') || true)
         ->once();
 
     $manifest
@@ -197,16 +197,16 @@ it('gracefully skips a provider that fails to boot', function () {
 });
 
 it('gracefully skips a provider that does not exist', function () {
-    $logger = mock(\Illuminate\Log\LogServiceProvider::class);
+    $handler = mock(\Illuminate\Contracts\Debug\ExceptionHandler::class);
     $manifest = mock(\Roots\Acorn\PackageManifest::class);
     $app = new Application();
 
-    $app->singleton('log', fn () => $logger);
+    $app->singleton(\Illuminate\Contracts\Debug\ExceptionHandler::class, fn () => $handler);
     $app->singleton(\Illuminate\Foundation\PackageManifest::class, fn () => $manifest);
 
-    $logger
-        ->shouldReceive('warning')
-        ->withArgs(fn ($message) => expect($message)->toContain('Skipping provider') || true)
+    $handler
+        ->shouldReceive('report')
+        ->withArgs(fn (\Roots\Acorn\Exceptions\SkipProviderException $e) => expect($e->getMessage())->toContain('Skipping provider') || true)
         ->once();
 
     $manifest


### PR DESCRIPTION
Offloads the logging of skipped providers to the exception handler.