### PR TITLE
🩹 allow using nonexistent `lang` directory

### DIFF
--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -120,7 +120,7 @@ class Application extends FoundationApplication
                 throw new Exception("The {$path_type} path type is not supported.");
             }
 
-            if ($path_type !== 'public' && (! is_dir($path) || ! is_readable($path))) {
+            if (! in_array($path_type, ['public', 'lang']) && (! is_dir($path) || ! is_readable($path))) {
                 throw new Exception("The {$path} directory must be present.");
             }
 

--- a/tests/Application/ApplicationTest.php
+++ b/tests/Application/ApplicationTest.php
@@ -34,7 +34,7 @@ it('rejects invalid custom paths', function () {
 
     $app->usePaths([
         'app' => $this->fixture('use_paths/app'),
-        'lang' => __DIR__ . '/this/does/not/exist',
+        'bootstrap' => __DIR__ . '/this/does/not/exist',
     ]);
 })->throws(Exception::class);
 
@@ -44,6 +44,15 @@ it('allows invalid public path', function () {
     $app->usePaths([
         'app' => $this->fixture('use_paths/app'),
         'public' => __DIR__ . '/this/does/not/exist',
+    ]);
+})->not->throws(Exception::class);
+
+it('allows invalid lang path', function () {
+    $app = new Application();
+
+    $app->usePaths([
+        'app' => $this->fixture('use_paths/app'),
+        'lang' => __DIR__ . '/this/does/not/exist',
     ]);
 })->not->throws(Exception::class);
 


### PR DESCRIPTION
This allows the `lang` path to be nonexistent. This path isn't used by default by Acorn, but it's still supported since it's a standard Laravel path.