### PR TITLE
🧑‍💻 improve bud hmr compatibility

### DIFF
--- a/src/Roots/Acorn/Assets/Bundle.php
+++ b/src/Roots/Acorn/Assets/Bundle.php
@@ -121,10 +121,15 @@ class Bundle implements BundleContract
 
     protected function isBudRequest()
     {
-        if (!$path = realpath("{$this->path}/hmr.json")) return false;
-        if (!$header = request()->header('x-bud-dev-origin')) return false;
+        if (
+            !$path = realpath("{$this->path}/hmr.json") ||
+            !$header = request()->header('x-bud-dev-origin')
+        ) {
+            return false;
+        }
 
         $dev = json_decode(file_get_contents($path))->dev;
+
         return str_contains($header, $dev->hostname);
     }
 
@@ -134,7 +139,7 @@ class Bundle implements BundleContract
             return $path;
         }
 
-        if($this->isBudRequest()) {
+        if ($this->isBudRequest()) {
             return join([$this->uri, $path]);
         }
     }

--- a/src/Roots/Acorn/Assets/Bundle.php
+++ b/src/Roots/Acorn/Assets/Bundle.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Collection;
 use Roots\Acorn\Assets\Concerns\Enqueuable;
 use Roots\Acorn\Assets\Contracts\Bundle as BundleContract;
 
-use function \request;
+use function request;
 
 class Bundle implements BundleContract
 {

--- a/src/Roots/Acorn/Assets/Bundle.php
+++ b/src/Roots/Acorn/Assets/Bundle.php
@@ -125,7 +125,7 @@ class Bundle implements BundleContract
             return $path;
         }
 
-        return "{$this->uri}/${path}";
+        return "{$this->uri}/{$path}";
     }
 
     protected function setRuntime()

--- a/src/Roots/Acorn/Assets/Bundle.php
+++ b/src/Roots/Acorn/Assets/Bundle.php
@@ -119,13 +119,24 @@ class Bundle implements BundleContract
         return self::$runtimes[$runtime] = file_get_contents("{$this->path}/{$runtime}");
     }
 
+    protected function isBudRequest()
+    {
+        if (!$path = realpath("{$this->path}/hmr.json")) return false;
+        if (!$header = request()->header('x-bud-dev-origin')) return false;
+
+        $dev = json_decode(file_get_contents($path))->dev;
+        return str_contains($header, $dev->hostname);
+    }
+
     protected function getUrl($path)
     {
         if (parse_url($path, PHP_URL_HOST)) {
             return $path;
         }
 
-        return "{$this->uri}/{$path}";
+        if($this->isBudRequest()) {
+            return join([$this->uri, $path]);
+        }
     }
 
     protected function setRuntime()

--- a/src/Roots/Acorn/Assets/Bundle.php
+++ b/src/Roots/Acorn/Assets/Bundle.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Collection;
 use Roots\Acorn\Assets\Concerns\Enqueuable;
 use Roots\Acorn\Assets\Contracts\Bundle as BundleContract;
 
+use function \request;
+
 class Bundle implements BundleContract
 {
     use Enqueuable;
@@ -121,10 +123,10 @@ class Bundle implements BundleContract
 
     protected function isBudRequest()
     {
-        if (
-            !$path = realpath("{$this->path}/hmr.json") ||
-            !$header = request()->header('x-bud-dev-origin')
-        ) {
+        !$path = realpath("{$this->path}/hmr.json");
+        !$header = request()->header('x-bud-dev-origin');
+
+        if (!$path || !$header) {
             return false;
         }
 
@@ -142,6 +144,8 @@ class Bundle implements BundleContract
         if ($this->isBudRequest()) {
             return join([$this->uri, $path]);
         }
+
+        return "{$this->uri}/${path}";
     }
 
     protected function setRuntime()

--- a/src/Roots/Acorn/Assets/Bundle.php
+++ b/src/Roots/Acorn/Assets/Bundle.php
@@ -7,8 +7,6 @@ use Illuminate\Support\Collection;
 use Roots\Acorn\Assets\Concerns\Enqueuable;
 use Roots\Acorn\Assets\Contracts\Bundle as BundleContract;
 
-use function request;
-
 class Bundle implements BundleContract
 {
     use Enqueuable;
@@ -121,28 +119,10 @@ class Bundle implements BundleContract
         return self::$runtimes[$runtime] = file_get_contents("{$this->path}/{$runtime}");
     }
 
-    protected function isBudRequest()
-    {
-        !$path = realpath("{$this->path}/hmr.json");
-        !$header = request()->header('x-bud-dev-origin');
-
-        if (!$path || !$header) {
-            return false;
-        }
-
-        $dev = json_decode(file_get_contents($path))->dev;
-
-        return str_contains($header, $dev->hostname);
-    }
-
     protected function getUrl($path)
     {
         if (parse_url($path, PHP_URL_HOST)) {
             return $path;
-        }
-
-        if ($this->isBudRequest()) {
-            return join([$this->uri, $path]);
         }
 
         return "{$this->uri}/${path}";

--- a/src/Roots/Acorn/Assets/Middleware/LaravelMixMiddleware.php
+++ b/src/Roots/Acorn/Assets/Middleware/LaravelMixMiddleware.php
@@ -1,11 +1,26 @@
 <?php
 
-namespace Roots\Acorn\Assets\Concerns;
+namespace Roots\Acorn\Assets\Middleware;
 
 use Illuminate\Support\Str;
 
-trait Mixable
+class LaravelMixMiddleware
 {
+    /**
+     * Handle the manifest config.
+     *
+     * @param array $config
+     * @return array
+     */
+    public function handle($config)
+    {
+        if ($url = $this->getMixHotUri($config['path'])) {
+            $config['url'] = $url;
+        }
+
+        return $config;
+    }
+
     /**
      * Get the URI to a Mix hot module replacement server.
      *

--- a/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
+++ b/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Roots\Acorn\Assets\Middleware;
+
+use Illuminate\Support\Str;
+
+class RootsBudMiddleware
+{
+    /**
+     * Handle the manifest config.
+     *
+     * @param array $config
+     * @return array
+     */
+    public function handle($config)
+    {
+        if ($url = $this->getBudDevUri($config['path'])) {
+            $config['url'] = $url;
+        }
+
+        return $config;
+    }
+
+    /**
+     * Get the URI to a Bud hot module replacement server.
+     *
+     * @link https://budjs.netlify.app/docs/bud.serve
+     *
+     * @param  string $path
+     * @return string|null
+     */
+    protected function getBudDevUri(string $path): ?string
+    {
+        if (! $path = realpath("{$path}/hmr.json")) {
+            return null;
+        }
+
+        if (! $header = $this->getHeader()) {
+            return null;
+        }
+
+        if (! $dev = optional(json_decode(file_get_contents($path)))->dev) {
+            return null;
+        }
+
+        if (strstr($header, $dev->hostname) === false) {
+            return null;
+        }
+
+        return Str::after($dev->href, ':');
+    }
+
+    /**
+     * Get the Bud dev server origin header.
+     *
+     * @return string|null|false
+     */
+    protected function getHeader()
+    {
+        return filter_input(INPUT_ENV, 'HTTP_X_BUD_DEV_ORIGIN', FILTER_SANITIZE_URL)
+            ?: filter_input(INPUT_SERVER, 'HTTP_X_BUD_DEV_ORIGIN', FILTER_SANITIZE_URL);
+    }
+}


### PR DESCRIPTION
This fixes HMR in roots/bud on subpages. See: https://github.com/roots/bud/issues/1070. 

`webpack-hot-middleware` must use webpack's `output.publicPath` internally. which.. makes sense. But, it's not ideal here.

In the long term I might do something like fork whm or implement my own HMR solution.  It makes me super uncomfortable to not have control over the public path. So, if you want to think about it as a temporary workaround.. I just want roots/sage users to have a nice experience.