### PR TITLE
🔧 app.debug => `WP_DEBUG` && `WP_DEBUG_DISPLAY`

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -41,7 +41,7 @@ return [
     |
     */
 
-    'debug' => (bool) WP_DEBUG_DISPLAY,
+    'debug' => WP_DEBUG && WP_DEBUG_DISPLAY,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Users might set WP_DEBUG_DISPLAY to true but assume that disabling WP_DEBUG will disable app.debug.

Context: app.debug is used to determine whether to display error messages to visitors, such as the Whoops or Symfony debug pages.