### PR TITLE
🧑‍💻 add error page to notify developers of breaking change

### DIFF
--- a/src/Roots/helpers.php
+++ b/src/Roots/helpers.php
@@ -38,7 +38,20 @@ function bundle(string $bundle): Bundle
  */
 function bootloader(?Application $app = null): Bootloader
 {
-    return Bootloader::getInstance($app);
+    $bootloader = Bootloader::getInstance($app);
+
+    \Roots\add_actions(['after_setup_theme', 'rest_api_init'], function () use ($bootloader) {
+        if (! $bootloader->getApplication()->hasBeenBootstrapped()) {
+            \Roots\wp_die(
+                'Acorn failed to boot. Run <code>\\Roots\\bootloader()->boot()</code>.<br><br>If you\'re using Sage, you need to <a href="https://github.com/roots/sage/blob/main/functions.php#L32">update this line <strong>functions.php</strong></a>',
+                '<code>\\Roots\\bootloader()</code> was called incorrectly.',
+                'Acorn &rsaquo; Boot Error',
+                'This message will be removed with the next beta release of Acorn.'
+            );
+        }
+    }, 6);
+
+    return $bootloader;
 }
 
 /**

--- a/src/Roots/helpers.php
+++ b/src/Roots/helpers.php
@@ -43,7 +43,7 @@ function bootloader(?Application $app = null): Bootloader
     \Roots\add_actions(['after_setup_theme', 'rest_api_init'], function () use ($bootloader) {
         if (! $bootloader->getApplication()->hasBeenBootstrapped()) {
             \Roots\wp_die(
-                'Acorn failed to boot. Run <code>\\Roots\\bootloader()->boot()</code>.<br><br>If you\'re using Sage, you need to <a href="https://github.com/roots/sage/blob/main/functions.php#L32">update this line <strong>functions.php</strong></a>',
+                'Acorn failed to boot. Run <code>\\Roots\\bootloader()->boot()</code>.<br><br>If you\'re using Sage, you need to <a href="https://github.com/roots/sage/blob/258d1f9675043108f7ecff0d4ed5586413a414e9/functions.php#L32">update this line <strong>functions.php</strong></a>',
                 '<code>\\Roots\\bootloader()</code> was called incorrectly.',
                 'Acorn &rsaquo; Boot Error',
                 'This message will be removed with the next beta release of Acorn.'


### PR DESCRIPTION
The changes to the Bootloader require an update to be made to Sage as noted in #169.

This warning should help beta testers who upgrade Acorn.

![image](https://user-images.githubusercontent.com/2104321/152100805-04ce91ca-61f8-479f-ace3-3f9398863d71.png)
