### PR TITLE
🐛 support composer.json without name property

### DIFF
--- a/src/Roots/Acorn/PackageManifest.php
+++ b/src/Roots/Acorn/PackageManifest.php
@@ -76,9 +76,9 @@ class PackageManifest extends FoundationPackageManifest
 
             $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());
 
-            return collect($packages)->mapWithKeys(function ($package) use ($path) {
+            return collect($packages)->mapWithKeys(function ($package) use ($path, $composerPath) {
                 return [
-                    $this->format($package['name'], dirname($path, 2)) =>
+                    $this->format($package['name'] ?? basename($composerPath), dirname($path, 2)) =>
                         $package['extra']['acorn'] ?? $package['extra']['laravel'] ?? []
                 ];
             })->each(function ($configuration) use (&$ignore) {


### PR DESCRIPTION
Unpublished composer.json files are not required to have a `name` property. This includes certain WordPress plugins that might have a composer.json that's used solely for dependency management and not for publishing the plugin.

closes #181 