### PR TITLE
♻️  use aggregate provider for SageFeatures

### DIFF
--- a/src/Roots/Acorn/Bootstrap/SageFeatures.php
+++ b/src/Roots/Acorn/Bootstrap/SageFeatures.php
@@ -3,36 +3,9 @@
 namespace Roots\Acorn\Bootstrap;
 
 use Illuminate\Contracts\Foundation\Application;
-use Roots\Acorn\Assets\AssetsServiceProvider;
-use Roots\Acorn\Sage\SageServiceProvider;
-use Roots\Acorn\View\ViewServiceProvider;
 
 class SageFeatures
 {
-    /**
-     * Sage Provider
-     *
-     * @var SageServiceProvider
-     */
-    protected $sage = SageServiceProvider::class;
-
-    /**
-     * A list of features to be loaded with Sage.
-     *
-     * @var array
-     */
-    protected $features = [];
-
-    /**
-     * A list of internal features to be loaded with Sage by default.
-     *
-     * @var array
-     */
-    protected $internalFeatures = [
-        AssetsServiceProvider::class,
-        ViewServiceProvider::class,
-    ];
-
     /**
      * Bootstrap the given application.
      *
@@ -41,22 +14,8 @@ class SageFeatures
      */
     public function bootstrap(Application $app)
     {
-        $this->features = $this->internalFeatures;
-
-        if (! $features = apply_filters('acorn/sage.features', get_theme_support('sage'))) {
-            return;
-        };
-
-        if (! empty($features) && is_array($features)) {
-            $this->features = $features;
-        }
-
-        if (array_intersect($this->internalFeatures, $this->features)) {
-            array_unshift($this->features, $this->sage);
-        }
-
-        foreach ($this->features as $feature) {
-            $app->register($feature);
+        if (get_theme_support('sage')) {
+            $app->register(\Roots\Acorn\Providers\SageFeaturesServiceProvider::class);
         }
     }
 }

--- a/src/Roots/Acorn/Providers/SageFeaturesServiceProvider.php
+++ b/src/Roots/Acorn/Providers/SageFeaturesServiceProvider.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Roots\Acorn\Providers;
+
+use Illuminate\Support\AggregateServiceProvider;
+
+class SageFeaturesServiceProvider extends AggregateServiceProvider
+{
+    protected $providers = [
+        \Roots\Acorn\Assets\AssetsServiceProvider::class,
+        \Roots\Acorn\View\ViewServiceProvider::class,
+        \Roots\Acorn\Sage\SageServiceProvider::class,
+    ];
+}

--- a/src/Roots/Acorn/Sage/SageServiceProvider.php
+++ b/src/Roots/Acorn/Sage/SageServiceProvider.php
@@ -2,9 +2,9 @@
 
 namespace Roots\Acorn\Sage;
 
+use Illuminate\Support\ServiceProvider;
 use Roots\Acorn\Sage\Sage;
 use Roots\Acorn\Sage\ViewFinder;
-use Roots\Acorn\ServiceProvider;
 
 use function Roots\add_filters;
 
@@ -28,10 +28,8 @@ class SageServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if ($this->app->bound('view')) {
-            $this->bindCompatFilters();
-            $this->bindViewFilters();
-        }
+        $this->bindCompatFilters();
+        $this->bindViewFilters();
     }
 
     /**


### PR DESCRIPTION
Ultimately, I'd like to see [ThemeServiceProvider](https://github.com/roots/sage/blob/main/app/Providers/ThemeServiceProvider.php) (which is [automatically registered](https://github.com/roots/sage/blob/main/composer.json#L68-L74)) extend the SageServiceProvider class so that Sage users can more easily extend and modify the changes made in Acorn. That would also allow us to remove [`add_theme_support('sage')`](https://github.com/roots/sage/blob/main/functions.php#L68).