### PR TITLE
🧑‍💻  provide helpful usage messages before things blow up

### DIFF
--- a/src/Roots/Acorn/Bootstrap/SageFeatures.php
+++ b/src/Roots/Acorn/Bootstrap/SageFeatures.php
@@ -4,18 +4,29 @@ namespace Roots\Acorn\Bootstrap;
 
 use Illuminate\Contracts\Foundation\Application;
 
+use function Roots\wp_die;
+
 class SageFeatures
 {
     /**
      * Bootstrap the given application.
      *
      * @param  \Roots\Acorn\Application  $app
+     * @deprecated
      * @return void
      */
     public function bootstrap(Application $app)
     {
         if (get_theme_support('sage')) {
-            $app->register(\Roots\Acorn\Providers\SageFeaturesServiceProvider::class);
+            wp_die(
+                sprintf(
+                    "Your <a href=\"https://github.com/roots/sage/blob/main/app/Providers/ThemeServiceProvider.php\">ThemeServiceProvider</a> should extend [%s].",
+                    \Roots\Acorn\Sage\SageServiceProvider::class,
+                ),
+                '<code>add_theme_support(\'sage\')</code> is not supported.',
+                'Acorn &rsaquo; Boot Error',
+                'Check out the <a href="https://github.com/roots/acorn/releases/tag/v2.0.0-beta.10">release notes</a> for more information.<br><br>This message will be removed with the next beta release of Acorn.'
+            );
         }
     }
 }

--- a/src/Roots/Acorn/Bootstrap/SageFeatures.php
+++ b/src/Roots/Acorn/Bootstrap/SageFeatures.php
@@ -6,13 +6,15 @@ use Illuminate\Contracts\Foundation\Application;
 
 use function Roots\wp_die;
 
+/**
+ * @deprecated
+ */
 class SageFeatures
 {
     /**
      * Bootstrap the given application.
      *
      * @param  \Roots\Acorn\Application  $app
-     * @deprecated
      * @return void
      */
     public function bootstrap(Application $app)

--- a/src/Roots/Acorn/Facade.php
+++ b/src/Roots/Acorn/Facade.php
@@ -4,6 +4,9 @@ namespace Roots\Acorn;
 
 use Illuminate\Support\Facades\Facade as FacadeBase;
 
+/**
+ * @deprecated
+ */
 abstract class Facade extends FacadeBase
 {
     //

--- a/src/Roots/Acorn/ServiceProvider.php
+++ b/src/Roots/Acorn/ServiceProvider.php
@@ -4,6 +4,9 @@ namespace Roots\Acorn;
 
 use Illuminate\Support\ServiceProvider as ServiceProviderBase;
 
+/**
+ * @deprecated
+ */
 abstract class ServiceProvider extends ServiceProviderBase
 {
     //

--- a/src/Roots/helpers.php
+++ b/src/Roots/helpers.php
@@ -40,15 +40,26 @@ function bootloader(?Application $app = null): Bootloader
 {
     $bootloader = Bootloader::getInstance($app);
 
+    /**
+     * @deprecated
+     */
     \Roots\add_actions(['after_setup_theme', 'rest_api_init'], function () use ($bootloader) {
-        if (! $bootloader->getApplication()->hasBeenBootstrapped()) {
-            \Roots\wp_die(
-                'Acorn failed to boot. Run <code>\\Roots\\bootloader()->boot()</code>.<br><br>If you\'re using Sage, you need to <a href="https://github.com/roots/sage/blob/258d1f9675043108f7ecff0d4ed5586413a414e9/functions.php#L32">update <strong>sage/functions.php:32</strong></a>',
-                '<code>\\Roots\\bootloader()</code> was called incorrectly.',
-                'Acorn &rsaquo; Boot Error',
-                'This message will be removed with the next beta release of Acorn.'
-            );
+        $app = $bootloader->getApplication();
+
+        if ($app->hasBeenBootstrapped()) {
+            return;
         }
+
+        if ($app->runningInConsole()) {
+            return $bootloader->boot();
+        }
+
+        \Roots\wp_die(
+            'Acorn failed to boot. Run <code>\\Roots\\bootloader()->boot()</code>.<br><br>If you\'re using Sage, you need to <a href="https://github.com/roots/sage/blob/258d1f9675043108f7ecff0d4ed5586413a414e9/functions.php#L32">update <strong>sage/functions.php:32</strong></a>',
+            '<code>\\Roots\\bootloader()</code> was called incorrectly.',
+            'Acorn &rsaquo; Boot Error',
+            'Check out the <a href="https://github.com/roots/acorn/releases/tag/v2.0.0-beta.10">release notes</a> for more information.<br><br>This message will be removed with the next beta release of Acorn.'
+        );
     }, 6);
 
     return $bootloader;


### PR DESCRIPTION
This builds upon #180. I'll look for other breaking changes and deprecations and try to keep them all in this PR so we can track them before the final release.

I've also added `@deprecated` so we can `grep` that to find these code blocks.

![image](https://user-images.githubusercontent.com/2104321/152737311-c2c2bd82-0ab1-4850-ac47-181e73a4fb6c.png)

x-ref #180