### PR TITLE
🩹 prevent looping acorn:init command

### DIFF
--- a/src/Roots/Acorn/Console/Commands/VendorPublishCommand.php
+++ b/src/Roots/Acorn/Console/Commands/VendorPublishCommand.php
@@ -17,16 +17,32 @@ class VendorPublishCommand extends FoundationVendorPublishCommand
     protected function publishItem($from, $to)
     {
         if (Str::startsWith($to, $vendor_path = dirname(__DIR__, 5))) {
-            $this->info("Cannot publish [{$from}] until Acorn is initialized.");
-
-            if (! $this->confirm("Would you like to initialize Acorn right now?", true)) {
-                throw new \Exception("Please run wp acorn acorn:init");
-            }
-
-            $this->call('acorn:init', ['--base' => $this->getLaravel()->basePath()]);
             $to = str_replace($vendor_path, $this->getLaravel()->basePath(), $to);
+
+            $this->callAcornInit($from, $to);
         }
 
         parent::publishItem($from, $to);
+    }
+
+    /**
+     * Call acorn:init if item cannot be published.
+     *
+     * @param string $from
+     * @param string $to
+     */
+    protected function callAcornInit($from, $to)
+    {
+        if (is_dir(dirname($to))) {
+            return;
+        }
+
+        $this->info("Cannot publish [{$from}] until Acorn is initialized.");
+
+        if (! $this->confirm("Would you like to initialize Acorn right now?", true)) {
+            throw new \Exception("Please run wp acorn acorn:init");
+        }
+
+        $this->call('acorn:init', ['--base' => $this->getLaravel()->basePath()]);
     }
 }


### PR DESCRIPTION
When publishing something with multiple files, acorn:init would be called for each file.

This PR resolves that by bailing early if the directory does not exist.

This is an imperfect solution. The proper solution would be to sniff out the directory type into which the item is being published (config, resource, storage, etc.) and only ensure that path exists.

But this will work for now.