### PR TITLE
✨ allow optional manifest param in asset helpers

### DIFF
--- a/src/Roots/helpers.php
+++ b/src/Roots/helpers.php
@@ -12,22 +12,32 @@ use Roots\Acorn\Bootloader;
  * Get asset from manifest
  *
  * @param  string $asset
+ * @param  string $manifest
  * @return Asset
  */
-function asset(string $asset): Asset
+function asset(string $asset, ?string $manifest = null): Asset
 {
-    return \app('assets.manifest')->asset($asset);
+    if (! $manifest) {
+        return \app('assets.manifest')->asset($asset);
+    }
+
+    return \app('assets')->manifest($manifest)->asset($asset);
 }
 
 /**
  * Get bundle from manifest
  *
  * @param  string $bundle
+ * @param  string $manifest
  * @return Bundle
  */
-function bundle(string $bundle): Bundle
+function bundle(string $bundle, ?string $manifest = null): Bundle
 {
-    return \app('assets.manifest')->bundle($bundle);
+    if (! $manifest) {
+        return \app('assets.manifest')->bundle($bundle);
+    }
+
+    return \app('assets')->manifest($manifest)->bundle($bundle);
 }
 
 /**


### PR DESCRIPTION
Given an assets config with multiple manifests...

```php
return [
    'default' => 'app',
    'manifests' => [
        'app' => [
            'path' => get_theme_file_path('public/app'),
            'url' => get_theme_file_uri('public/app'),
            'assets' => get_theme_file_path('public/app/manifest.json'),
            'bundles' => get_theme_file_path('public/app/entrypoints.json'),
        ],
        'editor' => [
            'path' => get_theme_file_path('public/editor'),
            'url' => get_theme_file_uri('public/editor'),
            'assets' => get_theme_file_path('public/editor/manifest.json'),
            'bundles' => get_theme_file_path('public/editor/entrypoints.json'),
        ],
    ]
]
```

You can now pass the key of non-default manifests to the helper methods.

```php
asset('my-asset.ext', 'editor');
bundle('my-editor-bundle', 'editor');
```

This includes the `@asset` helper.
```blade
<img src="@asset('my-asset-ext', 'editor')" alt="">
```