### PR TITLE
🩹 avoid passing second parameter to `class_exists`

### DIFF
--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -293,7 +293,9 @@ class Application extends FoundationApplication
     public function registerConfiguredProviders()
     {
         $providers = Collection::make($this->config['app.providers'])
-            ->filter('class_exists')
+            ->filter(function ($provider) {
+                return class_exists($provider);
+            })
             ->partition(function ($provider) {
                 return Str::startsWith($provider, ['Illuminate\\', 'Roots\\']);
             });


### PR DESCRIPTION
https://github.com/roots/acorn/pull/175/commits/50d7a3fdd042a0700cdf0798d11ace466e67d664 added provider class existence check, that would pass the key of `app.providers` as the second parameter to `class_exists`. 0 is a falsy value so `class_exists` does not check if the first provider class is autoloaded.

This PR uses closure instead of callable to avoid passing the second parameter to `class_exists`.
