### PR TITLE
🐛 fix config:cache (and optimize) command

### DIFF
--- a/src/Roots/Acorn/Console/Commands/ConfigCacheCommand.php
+++ b/src/Roots/Acorn/Console/Commands/ConfigCacheCommand.php
@@ -15,16 +15,21 @@ class ConfigCacheCommand extends FoundationConfigCacheCommand
      */
     protected function getFreshConfiguration()
     {
-        $app = $this->getLaravel();
+        add_filter('acorn/ready', '__return_true');
 
-        (new Bootloader(
-            ['acorn/fresh-config'],
-            get_class($this->getLaravel())
-        ))->call(function (Application $newApp) use (&$app) {
+        /** @var \Illuminate\Contracts\Foundation\Application */
+        $app = null;
+
+        $appClass = get_class($this->getLaravel());
+        $appClass::setInstance(null);
+
+        $bootloader = new Bootloader([], $appClass);
+
+        $bootloader();
+
+        $bootloader->call(function (Application $newApp) use (&$app) {
             $app = $newApp;
         });
-
-        do_action('acorn/fresh-config');
 
         return $app->make('config')->all();
     }


### PR DESCRIPTION
#202 fixed the package discovery issues, but one lingering related issue has persisted: `wp acorn optimize`. I'm not sure if this has ever worked correctly.

The issue was that despite attempting to get a fresh Application instance after clearing cache, the same instance was actually being returned since [`Bootloader` uses `Application::getInstance()`](https://github.com/roots/acorn/blob/2.x/src/Roots/Acorn/Bootloader.php#L204), so the crux of this fix is simply calling `Application::setInstance(null)` prior to booting a fresh instance.