### PR TITLE
👽 Enable `$_SERVER['HTTPS']` in console

### DIFF
--- a/src/Roots/Acorn/Bootstrap/CaptureRequest.php
+++ b/src/Roots/Acorn/Bootstrap/CaptureRequest.php
@@ -15,7 +15,25 @@ class CaptureRequest
      */
     public function bootstrap(Application $app)
     {
+        if ($app->runningInConsole()) {
+            $this->enableHttpsInConsole();
+        }
+
         $app->instance('request', \Illuminate\Http\Request::capture());
         Facade::clearResolvedInstance('request');
+    }
+
+    /**
+     * Enable $_SERVER[HTTPS] in a console environment.
+     *
+     * @return void
+     */
+    protected function enableHttpsInConsole()
+    {
+        $enable = apply_filters('acorn/enable_https_in_console', parse_url(get_option('home'), PHP_URL_SCHEME) === 'https');
+
+        if ($enable) {
+            $_SERVER['HTTPS'] = 'on';
+        }
     }
 }


### PR DESCRIPTION
Oftentimes developers will use WordPress functions to set Acorn config values, including values that reference URLs such as assets public path or disks. When running `wp acorn optimize`, this can result in undesirable outcomes if the developer has not manually set `$_SERVER['HTTPS']` during cli.

This PR enables `$_SERVER['HTTPS']` in a console environment when the home URL's scheme is HTTPS.

Developers can override this via `acorn/enable_https_in_console` filter.