### PR TITLE
enable configuration of loader file extension

### DIFF
--- a/src/Roots/Acorn/View/ViewServiceProvider.php
+++ b/src/Roots/Acorn/View/ViewServiceProvider.php
@@ -111,11 +111,12 @@ class ViewServiceProvider extends ViewServiceProviderBase
             $path = $this->getPath();
             $id = md5($this->getCompiled());
             $compiled_path = $app['config']['view.compiled'];
+            $compiled_extension = $app['config']->get('view.compiled_extension', 'php');
 
             $content = "<?= \\Roots\\view('{$view}', \$data ?? get_defined_vars())->render(); ?>"
                 . "\n<?php /**PATH {$path} ENDPATH**/ ?>";
 
-            if (! file_exists($loader = "{$compiled_path}/{$id}-loader.php")) {
+            if (! file_exists($loader = "{$compiled_path}/{$id}-loader.{$compiled_extension}")) {
                 file_put_contents($loader, $content);
             }
 


### PR DESCRIPTION
Upstream is set to start respecting the configuration of `view.compiled_extension` in the [ViewServiceProvider](https://github.com/laravel/framework/commit/68e41fd3691b9aa5548e07c5caf38696c4082513) at the next cut of 9.x. This change ensures the configuration is respected also for files created by the `makeLoader` macro. 

This creates a compatibility option for users at certain hosts, namely WP Engine, that restrict the PHP runtime from writing .php files to the disk in many scenarios. 