### PR TITLE
fix: Fixed Sage 10 view resolving as a child theme

### DIFF
--- a/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
+++ b/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
@@ -27,6 +27,13 @@ trait FiltersTemplates
      */
     public function filterTemplateInclude($file)
     {
+        // @README if we are not pointing to a blade template
+        // we should just return it as-is. This will allow Sage to be used
+        // as a child theme of a non sage theme
+        if (!preg_match('/\.blade\.php$/', $file)) {
+            return $file;
+        }
+
         $view = $this->fileFinder
             ->getPossibleViewNameFromPath($file = realpath($file));
 
@@ -40,7 +47,7 @@ trait FiltersTemplates
         $this->app['sage.view'] = $this->view->exists($view) ? $view : $file;
         $this->app['sage.data'] = $data;
 
-        return get_template_directory() . '/index.php';
+        return get_stylesheet_directory() . '/index.php';
     }
 
     /**


### PR DESCRIPTION
When using a Sage theme as a child theme of a non Acorn theme the templates aren't being picked up correctly because they are being parsed as blade templates
This commit fixes that by treating non-blade templates "as-is"

Secondly - in this instance - when used as a child template we should probably use the stylesheet directory method otherwise the index.php file of the parent theme is included.