### PR TITLE
🚸 display warning when PHP `>= 8.1.0 < 8.1.6`

### DIFF
--- a/src/Roots/Acorn/ComposerScripts.php
+++ b/src/Roots/Acorn/ComposerScripts.php
@@ -17,6 +17,15 @@ class ComposerScripts extends FoundationComposerScripts
     {
         $console = new Console(new Filesystem(), getcwd());
 
+        if (version_compare(PHP_VERSION, '8.1.0', '>=') && version_compare(PHP_VERSION, '8.1.6', '<')) {
+            printf(
+                "\033[93m⚠ PHP %s has a known bug that can impact certain environments. You should consider updating to a more recent version\n%s\n%s.\033[0m\n",
+                PHP_VERSION,
+                '🔗 https://github.com/roots/acorn/issues/217',
+                '🔗 https://github.com/php/php-src/pull/8297'
+            );
+        }
+
         $console->configClear();
         $console->clearCompiled();
     }

--- a/src/Roots/Acorn/ComposerScripts.php
+++ b/src/Roots/Acorn/ComposerScripts.php
@@ -19,7 +19,7 @@ class ComposerScripts extends FoundationComposerScripts
 
         if (version_compare(PHP_VERSION, '8.1.0', '>=') && version_compare(PHP_VERSION, '8.1.6', '<')) {
             printf(
-                "\033[93m⚠ PHP %s has a known bug that can impact certain environments. You should consider updating to a more recent version\n%s\n%s.\033[0m\n",
+                "\033[93m⚠ PHP %s has a known bug that can impact certain environments. You should consider updating to a more recent version.\n%s\n%s\033[0m\n",
                 PHP_VERSION,
                 '🔗 https://github.com/roots/acorn/issues/217',
                 '🔗 https://github.com/php/php-src/pull/8297'


### PR DESCRIPTION
This will address #217 by displaying a warning to users whenever Acorn's composer scripts are run, e.g., `Roots\Acorn\ComposerScripts::postAutoloadDump`.

Give this a 👍🏼 if you think it's worth adding because I'm still undecided.