### PR TITLE
🧑‍💻 Routing: Add ability to filter do_parse_request

### DIFF
--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -210,6 +210,12 @@ class Bootloader
             return;
         }
 
+        add_filter('do_parse_request', function ($do_parse, \WP $wp, $extra_query_vars) {
+            $do_parse = apply_filters('acorn/boot/do_parse_request', $do_parse, $wp, $extra_query_vars);
+
+            return $do_parse;
+        }, 100, 3);
+
         add_action('parse_request', function () use ($kernel, $request) {
             /** @var \Illuminate\Http\Response */
             $response = $kernel->handle($request);

--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -211,7 +211,7 @@ class Bootloader
         }
 
         add_filter('do_parse_request', fn ($do_parse, \WP $wp, $extra_query_vars) =>
-            apply_filters('acorn/boot/do_parse_request', $do_parse, $wp, $extra_query_vars),
+            apply_filters('acorn/router/do_parse_request', $do_parse, $wp, $extra_query_vars),
         100, 3);
 
         add_action('parse_request', function () use ($kernel, $request) {

--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -210,11 +210,9 @@ class Bootloader
             return;
         }
 
-        add_filter('do_parse_request', function ($do_parse, \WP $wp, $extra_query_vars) {
-            $do_parse = apply_filters('acorn/boot/do_parse_request', $do_parse, $wp, $extra_query_vars);
-
-            return $do_parse;
-        }, 100, 3);
+        add_filter('do_parse_request', fn ($do_parse, \WP $wp, $extra_query_vars) =>
+            apply_filters('acorn/boot/do_parse_request', $do_parse, $wp, $extra_query_vars),
+        100, 3);
 
         add_action('parse_request', function () use ($kernel, $request) {
             /** @var \Illuminate\Http\Response */


### PR DESCRIPTION
Ref #249

This PR adds the ability to filter `do_parse_request` prior to routing request being handled

(I'm not married to the `acorn/boot/do_parse_request` filter name)