### PR TITLE
Change return type from array to string[]

### DIFF
--- a/src/Roots/Acorn/Console/Commands/stubs/composer.stub
+++ b/src/Roots/Acorn/Console/Commands/stubs/composer.stub
@@ -9,7 +9,7 @@ class DummyClass extends Composer
     /**
      * List of views served by this composer.
      *
-     * @var array
+     * @var string[]
      */
     protected static $views = [
         DummyViews


### PR DESCRIPTION
Return type of the $views property should be the same as the parent class.