### PR TITLE
🔧 Add cache commands

### DIFF
--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -14,6 +14,8 @@ class Kernel extends FoundationConsoleKernel
      * @var array
      */
     protected $commands = [
+        \Illuminate\Cache\Console\ClearCommand::class,
+        \Illuminate\Cache\Console\ForgetCommand::class,
         \Illuminate\Foundation\Console\ClearCompiledCommand::class,
         \Illuminate\Foundation\Console\ComponentMakeCommand::class,
         \Illuminate\Foundation\Console\ConfigClearCommand::class,


### PR DESCRIPTION
This PR enables the `cache:clear` and `cache:forget` commands for Acorn CLI

```
$ wp acorn cache:forget test

   INFO  The [test] key has been removed from the cache.

$ wp acorn cache:clear

   INFO  Application cache cleared successfully.
```