### PR TITLE
PHP 8.2: ${var} string interpolation deprecated

### DIFF
--- a/src/Roots/Acorn/PackageManifest.php
+++ b/src/Roots/Acorn/PackageManifest.php
@@ -64,7 +64,7 @@ class PackageManifest extends FoundationPackageManifest
         $packages = array_reduce($this->composerPaths, function ($all, $composerPath) {
             $packages = [];
 
-            $path = "${composerPath}/vendor/composer/installed.json";
+            $path = "{$composerPath}/vendor/composer/installed.json";
 
             if ($this->files->exists($path)) {
                 $installed = json_decode($this->files->get($path), true);
@@ -72,7 +72,7 @@ class PackageManifest extends FoundationPackageManifest
                 $packages = $installed['packages'] ?? $installed;
             }
 
-            $packages[] = json_decode($this->files->get("${composerPath}/composer.json"), true);
+            $packages[] = json_decode($this->files->get("{$composerPath}/composer.json"), true);
 
             $ignoreAll = in_array('*', $ignore = $this->packagesToIgnore());
 
@@ -111,7 +111,7 @@ class PackageManifest extends FoundationPackageManifest
     protected function packagesToIgnore()
     {
         return array_reduce($this->composerPaths, function ($ignore, $composerPath) {
-            $path = "${composerPath}/composer.json";
+            $path = "{$composerPath}/composer.json";
 
             if (! $this->files->exists($path)) {
                 return $ignore;


### PR DESCRIPTION
On a fresh install of PHP 8.2 and running Acorn inside my theme, i receive these notifications in the debug.log and /wp-admin dashboard alerts.

```
[28-Mar-2023 17:27:36 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /app/web/app/themes/firescript-cms/vendor/roots/acorn/src/Roots/Acorn/PackageManifest.php on line 67
[28-Mar-2023 17:27:36 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /app/web/app/themes/firescript-cms/vendor/roots/acorn/src/Roots/Acorn/PackageManifest.php on line 75
[28-Mar-2023 17:27:36 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /app/web/app/themes/firescript-cms/vendor/roots/acorn/src/Roots/Acorn/PackageManifest.php on line 114
```
This change fixes the notice.

https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated#dollar-outside