### PR TITLE
Added explicit property 'protected Filesystem ' to remove deprecated …

### DIFF
--- a/src/Roots/Acorn/Sage/Sage.php
+++ b/src/Roots/Acorn/Sage/Sage.php
@@ -43,7 +43,14 @@ class Sage
      *
      * @var ViewFactory
      */
-    protected $view;
+    protected          $view;
+
+    /**
+     * The Filesystem instance.
+     *
+     * @var Filesystem
+     */
+    private Filesystem $files;
 
     /**
      * Creates a new Sage instance.


### PR DESCRIPTION
…notice in Sage class.

This should fix the "Creation of dynamic property Roots\Acorn\Sage\Sage::$files is deprecated" notice.