### PR TITLE
🧑‍💻 Add .devcontainer

### DIFF
--- a/.devcontainer/.gitignore
+++ b/.devcontainer/.gitignore
@@ -1,0 +1,2 @@
+docker-compose.override.yml
+.env

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,58 @@
+ARG PHP_IMAGE=8-fpm-bookworm
+FROM php:${PHP_IMAGE}
+
+LABEL maintainer="Roots Team"
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV TZ=UTC
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Install dependencies
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+      jq \
+      mariadb-client \
+      vim \
+      zip \
+    && apt-get -y autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+# Install PHP extensions
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+      ghostscript \
+      libfreetype6-dev \
+      libjpeg-dev \
+      libmagickwand-dev \
+      libpng-dev \
+      libzip-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j "$(nproc)" \
+      bcmath \
+      exif \
+      gd \
+      mysqli \
+      opcache \
+      pdo \
+      pdo_mysql \
+      zip \
+    && pecl install imagick-3.7.0 && docker-php-ext-enable imagick \
+    && pecl install -o -f redis && docker-php-ext-enable redis \
+    && pecl install xdebug-3.2.1 && docker-php-ext-enable xdebug \
+    && apt-get -y autoremove && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && composer clear-cache \
+    && echo "export PATH=${PATH}:./vendor/bin:/roots/app/vendor/bin" >> ~/.bashrc
+
+# Install wp-cli
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+    && chmod +x wp-cli.phar \
+    && mv wp-cli.phar /usr/local/bin/wp \
+    && mkdir -p /etc/bash_completion.d \
+    && curl -O https://raw.githubusercontent.com/wp-cli/wp-cli/master/utils/wp-completion.bash \
+    && mv wp-completion.bash /etc/bash_completion.d/wp-completion.bash
+
+USER vscode
+

--- a/.devcontainer/config/app/.env.example
+++ b/.devcontainer/config/app/.env.example
@@ -1,0 +1,21 @@
+DB_NAME='database_name'
+DB_USER='database_user'
+DB_PASSWORD='database_password'
+DB_HOST='database'
+DB_PREFIX='wp_'
+WP_ENV='development'
+WP_HOME='http://localhost:8080'
+WP_SITEURL="${WP_HOME}/wp"
+WP_DEBUG_LOG='true'
+
+# Generate your keys here: https://roots.io/salts.html
+AUTH_KEY='generateme'
+SECURE_AUTH_KEY='generateme'
+LOGGED_IN_KEY='generateme'
+NONCE_KEY='generateme'
+AUTH_SALT='generateme'
+SECURE_AUTH_SALT='generateme'
+LOGGED_IN_SALT='generateme'
+NONCE_SALT='generateme'
+
+ACORN_ENABLE_EXPIRIMENTAL_ROUTER='true'

--- a/.devcontainer/config/app/php.ini
+++ b/.devcontainer/config/app/php.ini
@@ -1,0 +1,24 @@
+[PHP]
+memory_limit = 128M
+post_max_size = 100M
+upload_max_filesize = 100M
+variables_order = EGPCS
+date.timezone = UTC
+display_errors = Off
+log_errors = On
+
+[opcache]
+opcache.enable_cli = 1
+opcache.memory_consumption = 128
+opcache.interned_strings_buffer = 8
+opcache.max_accelerated_files = 4000
+opcache.revalidate_freq = 2
+opcache.fast_shutdown = 1
+
+[xdebug]
+xdebug.client_port = 9003
+xdebug.client_host = host.docker.internal
+
+[session]
+session.save_handler = redis
+session.save_path = "tcp://cache:6379"

--- a/.devcontainer/config/web/default.conf
+++ b/.devcontainer/config/web/default.conf
@@ -1,0 +1,50 @@
+server {
+  listen 80 default;
+  listen [::]:80;
+
+  # listen 443 ssl;
+  # listen [::]:443 ssl ipv6only=on;
+  # ssl_certificate /etc/nginx/ssl/default.crt;
+  # ssl_certificate_key /etc/nginx/ssl/default.key;
+
+  add_header X-Frame-Options "SAMEORIGIN";
+  add_header X-Content-Type-Options "nosniff";
+  charset utf-8;
+
+  server_name web.local web;
+  root /roots/app/public;
+  index index.php index.html;
+
+  error_log  /dev/stderr info;
+  access_log /dev/stdout;
+
+  client_max_body_size 100M;
+
+  location / {
+    try_files $uri $uri/ /index.php$is_args$args;
+  }
+
+  location ~ \.php$ {
+    try_files $uri /index.php =404;
+    fastcgi_pass php-upstream:9000;
+    fastcgi_index index.php;
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_read_timeout 600;
+    include fastcgi_params;
+  }
+
+  if (!-e $request_filename) {
+    rewrite ^.*$ /index.php last;
+  }
+
+  location = /favicon.ico {
+    access_log off;
+    log_not_found off;
+  }
+  location = /robots.txt  {
+    access_log off;
+    log_not_found off;
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,45 @@
+{
+  "name": "Acorn Development",
+  "dockerComposeFile": ["docker-compose.yml"],
+  "service": "acorn.test",
+  "workspaceFolder": "/roots",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": "true",
+      "username": "vscode",
+      "userUid": "1000",
+      "userGid": "1000",
+      "upgradePackages": "true"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {},
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "latest"
+    }
+  },
+  "initializeCommand": "[ ! -f '.devcontainer/.env' ] && cp '.devcontainer/config/app/.env.example' '.devcontainer/.env' || true",
+  "onCreateCommand": "sudo chmod +x ./${localWorkspaceFolderBasename}/.devcontainer/install.sh && ./${localWorkspaceFolderBasename}/.devcontainer/install.sh",
+  "postCreateCommand": "sudo chmod +x ./${localWorkspaceFolderBasename}/.devcontainer/setup.sh && ./${localWorkspaceFolderBasename}/.devcontainer/setup.sh",
+  "forwardPorts": [],
+  "containerEnv": {
+    "APP_SERVICE": "acorn.test",
+    "WORKSPACE_FOLDER": "${containerWorkspaceFolder}/${localWorkspaceFolderBasename}"
+  },
+  "runServices": [
+    "cache",
+    "database",
+    "mail",
+    "web"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "mikestead.dotenv",
+        "amiralizadeh9480.laravel-extra-intellisense",
+        "ryannaddy.laravel-artisan",
+        "onecentlin.laravel5-snippets",
+        "onecentlin.laravel-blade"
+      ],
+      "settings": {}
+    }
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,144 @@
+version: '3.9'
+
+services:
+  acorn.test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: roots/dev-8.2
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    environment:
+      PHP_IDE_CONFIG: '${PHP_IDE_CONFIG:-serverName=acorn}'
+      XDEBUG_MODE: '${XDEBUG_MODE:-develop,debug}'
+      XDEBUG_CONFIG: '${XDEBUG_CONFIG:-client_port=9003 client_host=host.docker.internal discover_client_host=true}'
+      REPOSITORY_URL: '${REPOSITORY_URL:-https://github.com/roots/bedrock.git}'
+    volumes:
+      - ~/.ssh:/home/vscode/.ssh:ro
+      - 'app:/roots/app'
+      - '..:/roots/acorn:cached'
+      - './config/app/php.ini:/usr/local/etc/php/conf.d/99-overrides.ini'
+    networks:
+      - acorn
+    depends_on:
+      - mail
+      - database
+      - cache
+    restart: always
+
+  web:
+    image: nginx:latest
+    ports:
+      - '${FORWARD_WEB_PORT:-8080}:80'
+    volumes:
+      - app:/roots/app:ro
+      - ./config/web/default.conf:/etc/nginx/conf.d/default.conf
+    links:
+      - acorn.test:php-upstream
+    networks:
+      - acorn
+
+  database:
+    image: 'mariadb:10'
+    ports:
+      - '${FORWARD_DB_PORT:-3306}:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_DATABASE: '${DB_NAME}'
+      MYSQL_USER: '${DB_USER}'
+      MYSQL_PASSWORD: '${DB_PASSWORD}'
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+      - 'database:/var/lib/mysql'
+    networks:
+      - acorn
+    healthcheck:
+      test: ['CMD', 'mysqladmin', 'ping', '-p${DB_PASSWORD}']
+      retries: 3
+      timeout: 5s
+
+  cache:
+    image: 'redis:alpine'
+    ports:
+      - '${FORWARD_REDIS_PORT:-6379}:6379'
+    environment:
+      ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+      - 'cache:/data'
+    networks:
+      - acorn
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      retries: 3
+      timeout: 5s
+
+  storage:
+    image: 'minio/minio:latest'
+    ports:
+      - '${FORWARD_MINIO_PORT:-9000}:9000'
+      - '${FORWARD_MINIO_CONSOLE_PORT:-8900}:8900'
+    environment:
+      MINIO_ACCESS_KEY: '${MINIO_ACCESS_KEY}'
+      MINIO_SECRET_KEY: '${MINIO_SECRET_KEY}'
+    volumes:
+      - 'storage:/data'
+    networks:
+      - acorn
+    healthcheck:
+      test: ['CMD', 'curl', '-f', 'http://localhost:9000/minio/health/live']
+      retries: 3
+      timeout: 5s
+
+  browser:
+    image: 'selenium/standalone-chrome'
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    networks:
+      - acorn
+
+  mail:
+    image: 'axllent/mailpit:latest'
+    ports:
+      - '${FORWARD_MAILPIT_PORT:-1025}:1025'
+      - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
+    networks:
+      - acorn
+
+  websocket:
+    image: 'quay.io/soketi/soketi:latest-16-alpine'
+    environment:
+      SOKETI_DEBUG: '${SOKETI_DEBUG:-1}'
+      SOKETI_METRICS_SERVER_PORT: '9601'
+      SOKETI_DEFAULT_APP_ID: '${PUSHER_APP_ID}'
+      SOKETI_DEFAULT_APP_KEY: '${PUSHER_APP_KEY}'
+      SOKETI_DEFAULT_APP_SECRET: '${PUSHER_APP_SECRET}'
+    ports:
+      - '${PUSHER_PORT:-6001}:6001'
+      - '${PUSHER_METRICS_PORT:-9601}:9601'
+    networks:
+      - acorn
+
+  search:
+    image: 'getmeili/meilisearch:latest'
+    ports:
+      - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
+    volumes:
+      - 'search:/meili_data'
+    networks:
+      - acorn
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--spider', 'http://localhost:7700/health']
+      retries: 3
+      timeout: 5s
+
+networks:
+  acorn:
+    driver: bridge
+
+volumes:
+  app:
+  database:
+  cache:
+  storage:
+  search:

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+
+set -eux
+
+# Add a welcome message
+echo '👋 Welcome to Roots Development 🌱' | sudo tee /usr/local/etc/vscode-dev-containers/first-run-notice.txt
+
+WORKSPACE_FOLDER="${WORKSPACE_FOLDER:-"${PWD##*/}"}"
+
+# This is the default .env file used by the application
+FALLBACK_APP_ENV_FILE="${WORKSPACE_FOLDER}/.devcontainer/config/app/.env.example";
+APP_ENV_FILE="${FALLBACK_APP_ENV_FILE}";
+
+# If .env file exists in the workspace, let's use that instead
+if [ ! -z ${APP_ENV+x} ] && [ -f "${WORKSPACE_FOLDER}/.devcontainer/.env.${APP_ENV}" ]; then
+  APP_ENV_FILE="${WORKSPACE_FOLDER}/.devcontainer/.env.${APP_ENV}";
+elif [ -f "${WORKSPACE_FOLDER}/.devcontainer/.env" ]; then
+  APP_ENV_FILE="${WORKSPACE_FOLDER}/.devcontainer/.env";
+fi
+
+. "${APP_ENV_FILE}";
+# source our application env vars
+
+REPOSITORY_URL="${REPOSITORY_URL:-'https://github.com/roots/bedrock.git'}"
+
+sudo chown -R vscode:www-data /roots
+cd /roots/app
+
+# if composer.json already exists, exit early
+if [ -f "composer.json" ]; then
+  exit 0
+fi
+
+# Clone the repository
+git clone --depth=1 ${REPOSITORY_URL} . \
+  && rm -rf .git
+
+# if composer.json does not exist, exit with error message
+if [ ! -f "composer.json" ]; then
+  echo "composer.json not found in /roots/app"
+  exit 1
+fi
+
+# copy .env file if APP_ENV_FILE is default, otherwise link .env file
+[ "${APP_ENV_FILE}" = "${FALLBACK_APP_ENV_FILE}" ] \
+  && cp "${APP_ENV_FILE}" /roots/app/.env \
+  || ln -fs "${APP_ENV_FILE}" /roots/app/.env
+
+# use `public` instead of `web` for the document root
+if [ -d "web" ]; then
+  mv web public \
+    && sed -i 's/web/public/g' wp-cli.yml \
+    && sed -i 's/web\/wp/public\/wp/g' composer.json \
+    && sed -i 's/web\/app/public\/app/g' composer.json
+
+  if [ -f 'config/application.php' ]; then
+    sed -i 's/\/web/\/public/g' config/application.php
+  elif [ -f 'bedrock/application.php' ]; then
+    sed -i 's/\/web/\/public/g' bedrock/application.php
+  fi
+fi
+
+cd /roots/app
+
+rm wp-cli.yml
+# Install Composer dependencies
+composer -d /roots/app install --no-progress --optimize-autoloader --prefer-dist --no-interaction
+
+# Link the workspace folder
+if cat "${WORKSPACE_FOLDER}/composer.json" | jq '.type' | grep -q wordpress-theme; then
+  ln -fs "${WORKSPACE_FOLDER}" "/roots/app/public/app/themes/$(basename ${WORKSPACE_FOLDER})"
+elif cat "${WORKSPACE_FOLDER}/composer.json" | jq '.type' | grep -q wordpress-plugin; then
+  ln -fs "${WORKSPACE_FOLDER}" "/roots/app/public/app/plugins/$(basename ${WORKSPACE_FOLDER})"
+elif cat "${WORKSPACE_FOLDER}/composer.json" | jq '.type' | grep -q wordpress-muplugin; then
+  ln -fs "${WORKSPACE_FOLDER}" "/roots/app/public/app/mu-plugins/$(basename ${WORKSPACE_FOLDER})"
+else
+  cat /roots/app/composer.json | jq ".repositories += [{ type: \"path\", url: \"${WORKSPACE_FOLDER}\" }]" > /roots/app/composer.tmp \
+  && rm /roots/app/composer.json \
+  && mv /roots/app/composer.tmp /roots/app/composer.json \
+  && composer require -d /roots/app $(cat "${WORKSPACE_FOLDER}/composer.json" | jq '.name' | tr -d '"')
+fi
+
+composer remove -d /roots/app wpackagist-theme/twentytwentythree
+composer require -d /roots/app roots/soil
+
+# Set filesystem permissions
+sudo chown -R vscode:www-data /roots/app
+sudo find /roots/app/ -type d -exec chmod g+s {} \;
+sudo chmod g+w -R /roots/app
+
+cd /roots
+
+# wp-cli.yml file
+cat <<WPCLI > /roots/wp-cli.yml
+path: /roots/app/public/wp
+server:
+  docroot: /roots/app/public
+WPCLI
+
+# Install `wp dotenv` and `wp login` commands
+wp package install aaemnnosttv/wp-cli-dotenv-command 2>/dev/null
+wp package install aaemnnosttv/wp-cli-login-command 2>/dev/null

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -76,7 +76,7 @@ else
   cat /roots/app/composer.json | jq ".repositories += [{ type: \"path\", url: \"${WORKSPACE_FOLDER}\" }]" > /roots/app/composer.tmp \
   && rm /roots/app/composer.json \
   && mv /roots/app/composer.tmp /roots/app/composer.json \
-  && composer require -d /roots/app $(cat "${WORKSPACE_FOLDER}/composer.json" | jq '.name' | tr -d '"')
+  && composer require -d /roots/app $(cat "${WORKSPACE_FOLDER}/composer.json" | jq '.name' | tr -d '"') --no-interaction
 fi
 
 composer remove -d /roots/app wpackagist-theme/twentytwentythree

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -48,10 +48,10 @@ fi
 
 # use `public` instead of `web` for the document root
 if [ -d "web" ]; then
-  mv web public \
-    && sed -i 's/web/public/g' wp-cli.yml \
-    && sed -i 's/web\/wp/public\/wp/g' composer.json \
-    && sed -i 's/web\/app/public\/app/g' composer.json
+  mv web public
+  sed -i 's/web\/wp/public\/wp/g' composer.json
+  sed -i 's/web\/app/public\/app/g' composer.json
+  [ -f 'wp-cli.yml' ] && sed -i 's/web/public/g' wp-cli.yml || true
 
   if [ -f 'config/application.php' ]; then
     sed -i 's/\/web/\/public/g' config/application.php

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -62,7 +62,6 @@ fi
 
 cd /roots/app
 
-rm wp-cli.yml
 # Install Composer dependencies
 composer -d /roots/app install --no-progress --optimize-autoloader --prefer-dist --no-interaction
 

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+set -eux
+
+# Install volta
+curl https://get.volta.sh | bash -s -- --version latest
+export VOLTA_HOME="${HOME}/.volta"
+export PATH="${VOLTA_HOME}/bin:${PATH}"
+volta install node
+volta install yarn
+
+WORKSPACE_FOLDER="${WORKSPACE_FOLDER:-"${PWD##*/}"}"
+
+# source our application env vars to be used here
+. '/roots/app/.env';
+
+# We need a fallback URL if WP_HOME isn't set
+WP_HOME="${WP_HOME:-'http://localhost:8080'}"
+[ -z ${CODESPACE_NAME+x} ] || WP_HOME="https://${CODESPACE_NAME}-8080.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+
+# Show dirty git prompt
+cd /roots/acorn
+git config devcontainers-theme.show-dirty 1
+
+# Install WordPress and activate the plugin/theme.
+cd /roots/app
+
+yarn install || true
+yarn build || true
+
+wp db reset --yes
+wp core install --url="${WP_HOME}" --title="Roots Test" --admin_user="admin" --admin_email="admin@roots.test" --admin_password="password1" --skip-email
+
+# Add sage if there are no themes
+if [ ! "$(ls -d $(wp theme path --skip-plugins --skip-themes 2>/dev/null)/*/)" ]; then
+    composer require -d /roots/app roots/sage
+    wp theme activate sage
+fi
+
+install_theme() {
+    cd $1
+    pwd
+    if [ -f 'composer.json' ]; then
+        composer install || true
+    fi
+    if [ -f 'package-lock.json' ]; then
+        npm i || true
+        npm run-script build || true
+    elif [ -f 'package.json' ]; then
+        yarn install || true
+        yarn build || true
+    fi
+}
+
+find $(wp theme path --skip-plugins --skip-themes 2>/dev/null) -mindepth 1 -maxdepth 1 -type d | \
+    while read theme; do install_theme "$theme"; done
+
+wp dotenv salts regenerate --skip-plugins --skip-themes 2>/dev/null || true
+wp plugin activate soil --skip-plugins --skip-themes 2>/dev/null || true
+wp rewrite structure '%postname%' --hard --skip-plugins --skip-themes 2>/dev/null

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+/.devcontainer export-ignore
 /.github export-ignore
 /.gitattributes export-ignore
 /scripts export-ignore


### PR DESCRIPTION
It's not perfect. I'd like to iterate on this in the future. But it's working, and I'm finding it useful so far.

It runs nginx in a separate container, which was a goal of mine.

It provides other services as well in case we have a desire to test them.

It is compatible with both Bedrock and Radicle.
Copy .devcontainer/config/app/.env.example to .devcontainer/.env and append `REPOSITORY_URL='git@github.com:roots/radicle.git'` to test with Radicle.

Few ideas for the future
- Figure out how to get SSH forwarding to work. Right now I just set ~/.ssh as readonly volume to ~/.ssh in the container lol
- Clean up the scripts. Maybe use something similar to what Trellis does with its deployment-hooks.
- Possibly look into integrating directly with Trellis.
- Make it easier for developers to extend or modify the devcontainer without resulting in a dirty repo.
- Add SSL support
- Run node in a separate container

Credits

This was my first time messing with devcontainers. I borrowed from and learned from other examples.

- https://github.com/laravel/sail/
- https://github.com/Cyber-Duck/php-fpm-laravel/tree/8.2
- https://github.com/acadea/laravel-sail-nginx-php-fpm/
- https://github.com/wordpress/wordpress-develop/tree/trunk/.devcontainer