### PR TITLE
🧑‍💻 add route:cache and route:clear commands

### DIFF
--- a/src/Roots/Acorn/Console/Commands/RouteCacheCommand.php
+++ b/src/Roots/Acorn/Console/Commands/RouteCacheCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Roots\Acorn\Console\Commands;
+
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use Illuminate\Filesystem\Filesystem;
+use Roots\Acorn\Application;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
+use Roots\Acorn\Console\Concerns\GetsFreshApplication;
+use Roots\Acorn\Console\Console;
+
+class RouteCacheCommand extends \Illuminate\Foundation\Console\RouteCacheCommand
+{
+    use GetsFreshApplication {
+        getFreshApplication as protected parentGetFreshApplication;
+    }
+
+    protected $console;
+
+    public function __construct(Filesystem $files, Console $console)
+    {
+        parent::__construct($files);
+
+        $this->console = $console;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! Application::isExperimentalRouterEnabled()) {
+            return;
+        }
+
+        if (! $this->ensureDependenciesExist()) {
+            return;
+        }
+
+        parent::handle();
+    }
+
+    /**
+     * Ensure the dependencies for the database commands are available.
+     *
+     * @return bool
+     */
+    protected function ensureDependenciesExist()
+    {
+        if (class_exists(\Laravel\SerializableClosure\SerializableClosure::class)) {
+            return true;
+        }
+
+        $message = 'Route caching requires Serializable Closure (laravel/serializable-closure) package.';
+
+        if ($this->components->confirm("{$message} Would you like to install it?")) {
+            $this->installDependencies();
+            if ($this->console->acorn('route:cache') === 0) {
+                $this->components->info('Routes cached successfully.');
+            }
+        } else {
+            $this->components->error($message);
+        }
+
+        return false;
+    }
+
+    /**
+     * Install the command's dependencies.
+     *
+     * @return void
+     *
+     * @throws \Symfony\Component\Process\Exception\ProcessSignaledException
+     *
+     * @copyright Taylor Otwell
+     * @link https://github.com/laravel/framework/blob/9.x/src/Illuminate/Database/Console/DatabaseInspectionCommand.php
+     */
+    protected function installDependencies()
+    {
+        $command = collect($this->console->findComposer())
+            ->push('require laravel/serializable-closure')
+            ->implode(' ');
+
+        $process = Process::fromShellCommandline($command, null, null, null, null);
+
+        if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
+            try {
+                $process->setTty(true);
+            } catch (RuntimeException $e) {
+                $this->components->warn($e->getMessage());
+            }
+        }
+
+        try {
+            $process->run(fn ($type, $line) => $this->output->write($line));
+        } catch (ProcessSignaledException $e) {
+            if (extension_loaded('pcntl') && $e->getSignal() !== SIGINT) {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Get a fresh application instance.
+     *
+     * @return \Illuminate\Contracts\Foundation\Application
+     */
+    protected function getFreshApplication()
+    {
+        return tap($this->parentGetFreshApplication(), function ($app) {
+            $app->make(ConsoleKernelContract::class)->bootstrap();
+        });
+    }
+}

--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -26,6 +26,7 @@ class Kernel extends FoundationConsoleKernel
         \Illuminate\Foundation\Console\EnvironmentCommand::class,
         \Illuminate\Foundation\Console\PackageDiscoverCommand::class,
         \Illuminate\Foundation\Console\ProviderMakeCommand::class,
+        \Illuminate\Foundation\Console\RouteClearCommand::class,
         \Illuminate\Foundation\Console\RouteListCommand::class,
         \Illuminate\Foundation\Console\ViewCacheCommand::class,
         \Illuminate\Foundation\Console\ViewClearCommand::class,
@@ -37,6 +38,7 @@ class Kernel extends FoundationConsoleKernel
         \Roots\Acorn\Console\Commands\ConfigCacheCommand::class,
         \Roots\Acorn\Console\Commands\OptimizeClearCommand::class,
         \Roots\Acorn\Console\Commands\OptimizeCommand::class,
+        \Roots\Acorn\Console\Commands\RouteCacheCommand::class,
         \Roots\Acorn\Console\Commands\SummaryCommand::class,
         \Roots\Acorn\Console\Commands\VendorPublishCommand::class,
     ];


### PR DESCRIPTION
<details>
<summary>Running `wp acorn optimize` will now prompt users to download laravel/serializable-closure</summary>

![image](https://github.com/roots/acorn/assets/2104321/e3ff424a-5314-4050-83a1-787381379063)

</details>

<details>
<summary>If interaction is disabled, the prompt is skipped and an error is shown.</summary>

![image](https://github.com/roots/acorn/assets/2104321/4af7d609-eb8c-451b-9020-5adae2292897)

</details>

<details>
<summary>If user answers yes, the package is downloaded and routes are cached.</summary>

![image](https://github.com/roots/acorn/assets/2104321/e275d0ff-842b-44a5-9d61-14b9554b9f07)

</details>

<details>
<summary>If user does not have experimental routes enabled, the command is skipped.</summary>

![image](https://github.com/roots/acorn/assets/2104321/e69fcec3-d7ed-4b03-b985-fd0124184254)

</details>




**✨ Bonus**
Also squashed a bug in the `about` command! (I meant to make that its own PR but accidentally included it here.)