### PR TITLE
Exit parse_request to short circuit wordpress during custom routes.

### DIFF
--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -239,6 +239,8 @@ class Bootloader
             $body = $response->send();
 
             $kernel->terminate($request, $body);
+
+            exit;
         });
     }
 


### PR DESCRIPTION
This is the shortest pull request of all time ;). But it seems to work as described by the people who found it on discourse.

Fixes the issue described here:

https://discourse.roots.io/t/custom-route-includes-the-homepage-view/25462/5