### PR TITLE
Add Vite support

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => 'bud',
+    'default' => 'theme',
 
     /*
     |--------------------------------------------------------------------------
@@ -31,16 +31,11 @@ return [
     */
 
     'manifests' => [
-        'bud' => [
+        'theme' => [
             'path' => get_theme_file_path('public'),
             'url' => get_theme_file_uri('public'),
             'assets' => get_theme_file_path('public/manifest.json'),
             'bundles' => get_theme_file_path('public/entrypoints.json'),
         ],
-        'vite' => [
-            'path' => get_theme_file_path('public'),
-            'url' => get_theme_file_uri('public'),
-            'bundles' => get_theme_file_path('public/build/manifest.json'),
-        ],
-    ]
+    ],
 ];

--- a/config/assets.php
+++ b/config/assets.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => 'theme',
+    'default' => 'bud',
 
     /*
     |--------------------------------------------------------------------------
@@ -31,11 +31,16 @@ return [
     */
 
     'manifests' => [
-        'theme' => [
+        'bud' => [
             'path' => get_theme_file_path('public'),
             'url' => get_theme_file_uri('public'),
             'assets' => get_theme_file_path('public/manifest.json'),
             'bundles' => get_theme_file_path('public/entrypoints.json'),
-        ]
+        ],
+        'vite' => [
+            'path' => get_theme_file_path('public'),
+            'url' => get_theme_file_uri('public'),
+            'bundles' => get_theme_file_path('public/build/manifest.json'),
+        ],
     ]
 ];

--- a/src/Roots/Acorn/Assets/AssetsServiceProvider.php
+++ b/src/Roots/Acorn/Assets/AssetsServiceProvider.php
@@ -18,6 +18,8 @@ class AssetsServiceProvider extends ServiceProvider
             return new Manager($this->app->make('config')->get('assets'));
         });
 
+        $this->app->singleton('assets.vite', Vite::class);
+
         $this->app->singleton('assets.manifest', function ($app) {
             return $app['assets']->manifest($this->getDefaultManifest());
         });

--- a/src/Roots/Acorn/Assets/Vite.php
+++ b/src/Roots/Acorn/Assets/Vite.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roots\Acorn\Assets;
+
+use Illuminate\Foundation\Vite as LaravelVite;
+
+class Vite extends LaravelVite
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function assetPath($path, $secure = null)
+    {
+        return \Roots\asset($path)->uri();
+    }
+}

--- a/src/Roots/Acorn/Assets/Vite.php
+++ b/src/Roots/Acorn/Assets/Vite.php
@@ -1,15 +1,17 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Roots\Acorn\Assets;
 
-use Illuminate\Foundation\Vite as LaravelVite;
+use Illuminate\Foundation\Vite as FoundationVite;
 
-class Vite extends LaravelVite
+class Vite extends FoundationVite
 {
     /**
-     * {@inheritDoc}
+     * Generate an asset path for the application.
+     *
+     * @param  string  $path
+     * @param  bool|null  $secure
+     * @return string
      */
     protected function assetPath($path, $secure = null)
     {


### PR DESCRIPTION
This PR adds [Vite](https://vitejs.dev/) support if user wants to use it since Vite is already bundled with Acorn package.

I found that it almost working but [this line](https://github.com/roots/acorn/blob/main/src/Illuminate/Foundation/Vite.php#L667) causing the problem as it expects to return a string but instead uses `\Roots\asset()` function which returns `Asset` object therefore fails. I believe I cannot change `Illuminate` content so I just extend a new Vite class with Laravel's one and change one method

Usage example with [laravel-vite-plugin](https://github.com/laravel/vite-plugin/) with basic setup

```js
// vite.config

import { defineConfig } from 'vite';
import laravel from 'laravel-vite-plugin';

export default defineConfig({
    plugins: [
        laravel('resources/js/app.js'),
    ],
});
```

Needs to define `vite` as default manifest

```php
// config/assets.php

return [
    'default' => 'vite',

    'manifests' => [
        'theme' => [
           // ...
        ],
        'vite' => [
            'path' => get_theme_file_path('public'),
            'url' => get_theme_file_uri('public'),
            'bundles' => get_theme_file_path('public/build/manifest.json'),
        ],
    ]
];
```

and inject assets in the head (it is not using `wp_enqueue_` functions) something like

```php
// app/setup.php

add_action('wp_head', function () {
  echo app('assets.vite')('resources/js/app.js');
});
```

For a custom vite configuration (let's say I need to use another manifest filename) we still can use Laravel API for Vite

```js
// vite.config.js

export default defineConfig({
    build: {
      manifest: 'custom-manifest.json'
    },
    plugins: [
        laravel('resources/js/app.js'),
    ],
});
```

```php
// setup.php
add_action('wp_head', function () {
  echo app('assets.vite')->useManifestFilename('custom-manifest.json')('resources/js/app.js');
});

// config/assets.php
// Change manifest name
'bundles' => get_theme_file_path('public/build/custom-manifest.json'),
```
