### PR TITLE
Create FoundationServiceProvider.php

### DIFF
--- a/src/Roots/Acorn/Providers/FoundationServiceProvider.php
+++ b/src/Roots/Acorn/Providers/FoundationServiceProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Roots\Acorn\Providers;
+
+use Illuminate\Foundation\Providers\FormRequestServiceProvider;
+use Illuminate\Foundation\Providers\FoundationServiceProvider as BaseFoundationServiceProvider;
+
+class FoundationServiceProvider extends BaseFoundationServiceProvider
+{
+    /**
+     * The provider class names.
+     *
+     * @var string[]
+     */
+    protected $providers = [
+        FormRequestServiceProvider::class,
+    ];
+
+    /**
+     * The singletons to register into the container.
+     *
+     * @var array
+     */
+    public $singletons = [];
+}


### PR DESCRIPTION
Radicle (and so, Acorn) is missing the `FoundationServiceProvider`, causing multiple errors : 

- `\Illuminate\Http\Request` class is missing the `validate()` method
- The custom [FormRequests](https://laravel.com/docs/9.x/validation#form-request-validation) are not working, because of the missing call to the related service provider
- The dumper on Radicle is broken

By adding this Service provider to the `config/app.php` file, it fixes those errors.

```php
'providers' => [
    ...
    Roots\Acorn\Providers\FoundationServiceProvider::class,
],
```

Tested on Radicle stack.


