### PR TITLE
✨ Automatically expose public properties and methods on View Composers

### DIFF
--- a/src/Roots/Acorn/Assets/Asset/Asset.php
+++ b/src/Roots/Acorn/Assets/Asset/Asset.php
@@ -114,7 +114,7 @@ class Asset implements AssetContract
      *
      * @param  string  $mediatype MIME content type
      */
-    public function dataUrl(string $mediatype = null): string
+    public function dataUrl(?string $mediatype = null): string
     {
         if ($this->dataUrl) {
             return $this->dataUrl;
@@ -132,7 +132,7 @@ class Asset implements AssetContract
      *
      * @param  string  $mediatype MIME content type
      */
-    public function dataUri(string $mediatype = null): string
+    public function dataUri(?string $mediatype = null): string
     {
         return $this->dataUrl($mediatype);
     }

--- a/src/Roots/Acorn/Assets/Asset/TextAsset.php
+++ b/src/Roots/Acorn/Assets/Asset/TextAsset.php
@@ -40,7 +40,7 @@ class TextAsset extends Asset
      * @param  string  $charset Character encoding
      * @param  string  $urlencode List of characters to be percent-encoded
      */
-    public function dataUrl(string $mediatype = null, string $charset = null, string $urlencode = '%\'"'): string
+    public function dataUrl(?string $mediatype = null, ?string $charset = null, string $urlencode = '%\'"'): string
     {
         if ($this->dataUrl) {
             return $this->dataUrl;
@@ -72,7 +72,7 @@ class TextAsset extends Asset
      * @param  string  $charset Character encoding
      * @param  string  $urlencode List of characters to be percent-encoded
      */
-    public function dataUri(string $mediatype = null, string $charset = null, string $urlencode = '%\'"'): string
+    public function dataUri(?string $mediatype = null, ?string $charset = null, string $urlencode = '%\'"'): string
     {
         return $this->dataUrl($mediatype, $charset, $urlencode);
     }

--- a/src/Roots/Acorn/Assets/AssetFactory.php
+++ b/src/Roots/Acorn/Assets/AssetFactory.php
@@ -17,7 +17,7 @@ class AssetFactory
      * @param  string  $uri Remote URI
      * @param  string  $type Asset type
      */
-    public static function create(string $path, string $uri, string $type = null): AssetContract
+    public static function create(string $path, string $uri, ?string $type = null): AssetContract
     {
         if (! $type) {
             $type = pathinfo($path, PATHINFO_EXTENSION);

--- a/src/Roots/Acorn/Assets/Bundle.php
+++ b/src/Roots/Acorn/Assets/Bundle.php
@@ -44,7 +44,7 @@ class Bundle implements BundleContract
      *
      * @return Collection|$this
      */
-    public function css(callable $callable = null)
+    public function css(?callable $callable = null)
     {
         $styles = $this->conditional ? $this->bundle['css'] : [];
 
@@ -67,7 +67,7 @@ class Bundle implements BundleContract
      *
      * @return Collection|$this
      */
-    public function js(callable $callable = null)
+    public function js(?callable $callable = null)
     {
         $scripts = $this->conditional ? array_merge($this->bundle['js'], $this->bundle['mjs']) : [];
 

--- a/src/Roots/Acorn/Assets/Concerns/Enqueuable.php
+++ b/src/Roots/Acorn/Assets/Concerns/Enqueuable.php
@@ -18,7 +18,7 @@ trait Enqueuable
      *
      * @return Collection|$this
      */
-    abstract public function js(callable $callable = null);
+    abstract public function js(?callable $callable = null);
 
     /**
      * Get CSS files in bundle.
@@ -27,7 +27,7 @@ trait Enqueuable
      *
      * @return Collection|$this
      */
-    abstract public function css(callable $callable = null);
+    abstract public function css(?callable $callable = null);
 
     abstract public function runtime();
 

--- a/src/Roots/Acorn/Assets/Manager.php
+++ b/src/Roots/Acorn/Assets/Manager.php
@@ -66,7 +66,7 @@ class Manager
     /**
      * Get a Manifest
      */
-    public function manifest(string $name, array $config = null): ManifestContract
+    public function manifest(string $name, ?array $config = null): ManifestContract
     {
         $manifest = $this->manifests[$name] ?? $this->resolve($name, $config);
 

--- a/src/Roots/Acorn/Assets/Manifest.php
+++ b/src/Roots/Acorn/Assets/Manifest.php
@@ -17,7 +17,7 @@ class Manifest implements ManifestContract
 
     protected $uri;
 
-    public function __construct(string $path, string $uri, array $assets = [], array $bundles = null)
+    public function __construct(string $path, string $uri, array $assets = [], ?array $bundles = null)
     {
         $this->path = $path;
         $this->uri = $uri;

--- a/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
+++ b/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
@@ -13,7 +13,7 @@ class RootsBudMiddleware
      */
     protected $dev_origin;
 
-    public function __construct(string $dev_origin = null)
+    public function __construct(?string $dev_origin = null)
     {
         $this->dev_origin = $dev_origin;
     }

--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -60,7 +60,7 @@ class Bootloader
      *
      * @return static
      */
-    public static function getInstance(ApplicationContract $app = null)
+    public static function getInstance(?ApplicationContract $app = null)
     {
         return static::$instance ??= new static($app);
     }
@@ -68,7 +68,7 @@ class Bootloader
     /**
      * Create a new bootloader instance.
      */
-    public function __construct(ApplicationContract $app = null, Filesystem $files = null)
+    public function __construct(?ApplicationContract $app = null, ?Filesystem $files = null)
     {
         $this->app = $app;
         $this->files = $files ?? new Filesystem;

--- a/src/Roots/Acorn/DefaultProviders.php
+++ b/src/Roots/Acorn/DefaultProviders.php
@@ -25,7 +25,7 @@ class DefaultProviders extends DefaultProvidersBase
      *
      * @return void
      */
-    public function __construct(array $providers = null)
+    public function __construct(?array $providers = null)
     {
         parent::__construct($providers);
 

--- a/src/Roots/Acorn/Exceptions/SkipProviderException.php
+++ b/src/Roots/Acorn/Exceptions/SkipProviderException.php
@@ -12,7 +12,7 @@ class SkipProviderException extends InvalidArgumentException
      *
      * @return void
      */
-    public function __construct(string $message = '', int $code = 0, Throwable $previous = null, string $package = '')
+    public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null, string $package = '')
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Roots/Acorn/View/Composer.php
+++ b/src/Roots/Acorn/View/Composer.php
@@ -33,6 +33,23 @@ abstract class Composer
     protected $data;
 
     /**
+     * The properties / methods that should not be exposed.
+     *
+     * @var array
+     */
+    protected $except = [];
+
+    /**
+     * The default properties / methods that should not be exposed.
+     *
+     * @var array
+     */
+    protected $defaultExcept = [
+        'views',
+        'compose',
+    ];
+
+    /**
      * The list of views served by this composer.
      *
      * @return string|string[]

--- a/src/Roots/Acorn/View/Composer.php
+++ b/src/Roots/Acorn/View/Composer.php
@@ -5,11 +5,11 @@ namespace Roots\Acorn\View;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
-use Roots\Acorn\View\Concerns\ExtractsClassAsVariables;
+use Roots\Acorn\View\Composers\Concerns\Extractable;
 
 abstract class Composer
 {
-    use ExtractsClassAsVariables;
+    use Extractable;
 
     /**
      * The list of views served by this composer.

--- a/src/Roots/Acorn/View/Composer.php
+++ b/src/Roots/Acorn/View/Composer.php
@@ -94,7 +94,7 @@ abstract class Composer
             return array_merge(
                 $this->extractPublicProperties(),
                 $this->extractPublicMethods(),
-                $this->view->getData(),
+                $this->view->getData()
             );
         }
 

--- a/src/Roots/Acorn/View/Composer.php
+++ b/src/Roots/Acorn/View/Composer.php
@@ -5,9 +5,12 @@ namespace Roots\Acorn\View;
 use Illuminate\Support\Fluent;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
+use Roots\Acorn\View\Concerns\ExtractsClassAsVariables;
 
 abstract class Composer
 {
+    use ExtractsClassAsVariables;
+
     /**
      * List of views to receive data by this composer
      *
@@ -66,6 +69,14 @@ abstract class Composer
      */
     protected function merge()
     {
+        if (! $this->with() && ! $this->override()) {
+            return array_merge(
+                $this->extractPublicProperties(),
+                $this->extractPublicMethods(),
+                $this->view->getData(),
+            );
+        }
+
         return array_merge(
             $this->with(),
             $this->view->getData(),

--- a/src/Roots/Acorn/View/Composer.php
+++ b/src/Roots/Acorn/View/Composer.php
@@ -12,28 +12,28 @@ abstract class Composer
     use ExtractsClassAsVariables;
 
     /**
-     * List of views to receive data by this composer
+     * The list of views served by this composer.
      *
      * @var string[]
      */
     protected static $views;
 
     /**
-     * Current view
+     * The current view instance.
      *
-     * @var View
+     * @var \Illuminate\View\View
      */
     protected $view;
 
     /**
-     * Current view data
+     * The current view data.
      *
-     * @var Fluent
+     * @var \Illuminate\Support\Fluent
      */
     protected $data;
 
     /**
-     * List of views served by this composer
+     * The list of views served by this composer.
      *
      * @return string|string[]
      */
@@ -63,7 +63,7 @@ abstract class Composer
     }
 
     /**
-     * Data to be merged and passed to the view before rendering.
+     * The merged data to be passed to view before rendering.
      *
      * @return array
      */
@@ -85,7 +85,7 @@ abstract class Composer
     }
 
     /**
-     * Data to be passed to view before rendering
+     * The data passed to the view before rendering.
      *
      * @return array
      */
@@ -95,7 +95,7 @@ abstract class Composer
     }
 
     /**
-     * Data to be passed to view before rendering
+     * The override data passed to the view before rendering.
      *
      * @return array
      */

--- a/src/Roots/Acorn/View/Composer.php
+++ b/src/Roots/Acorn/View/Composer.php
@@ -45,8 +45,12 @@ abstract class Composer
      * @var array
      */
     protected $defaultExcept = [
-        'views',
+        'cache',
         'compose',
+        'override',
+        'toArray',
+        'views',
+        'with',
     ];
 
     /**
@@ -119,5 +123,27 @@ abstract class Composer
     protected function override()
     {
         return [];
+    }
+
+    /**
+     * Determine if the given property / method should be ignored.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    protected function shouldIgnore($name)
+    {
+        return str_starts_with($name, '__') ||
+            in_array($name, $this->ignoredMethods());
+    }
+
+    /**
+     * Get the methods that should be ignored.
+     *
+     * @return array
+     */
+    protected function ignoredMethods()
+    {
+        return array_merge($this->defaultExcept, $this->except);
     }
 }

--- a/src/Roots/Acorn/View/Composers/Concerns/Arrayable.php
+++ b/src/Roots/Acorn/View/Composers/Concerns/Arrayable.php
@@ -17,7 +17,7 @@ trait Arrayable
     public function toArray()
     {
         return collect((new ReflectionClass(static::class))->getMethods(ReflectionMethod::IS_PUBLIC))
-            ->reject(fn ($method) => $this->shouldIgnore($method->name))
+            ->reject(fn ($method) => $this->shouldIgnore($method->name) || $method->isStatic())
             ->mapWithKeys(function ($method) {
                 $data = $this->{$method->name}();
 

--- a/src/Roots/Acorn/View/Composers/Concerns/Arrayable.php
+++ b/src/Roots/Acorn/View/Composers/Concerns/Arrayable.php
@@ -10,13 +10,6 @@ use ReflectionMethod;
 trait Arrayable
 {
     /**
-     * Ignored Methods
-     *
-     * @var string[]
-     */
-    protected $ignore = [];
-
-    /**
      * Maps available class methods to an array.
      *
      * @return array
@@ -24,14 +17,7 @@ trait Arrayable
     public function toArray()
     {
         return collect((new ReflectionClass(static::class))->getMethods(ReflectionMethod::IS_PUBLIC))
-            ->filter(fn ($method) => ! in_array(
-                $method->name,
-                array_merge(
-                    $this->ignore,
-                    ['compose', 'toArray', 'with', 'views', 'override']
-                )
-            ))
-            ->filter(fn ($method) => ! Str::startsWith($method->name, ['__', 'cache']))
+            ->reject(fn ($method) => $this->shouldIgnore($method->name))
             ->mapWithKeys(function ($method) {
                 $data = $this->{$method->name}();
 

--- a/src/Roots/Acorn/View/Composers/Concerns/Cacheable.php
+++ b/src/Roots/Acorn/View/Composers/Concerns/Cacheable.php
@@ -5,8 +5,6 @@ namespace Roots\Acorn\View\Composers\Concerns;
 use BadMethodCallException;
 use Illuminate\Support\Facades\Cache;
 
-use function Roots\cache;
-
 trait Cacheable
 {
     /**

--- a/src/Roots/Acorn/View/Composers/Concerns/Extractable.php
+++ b/src/Roots/Acorn/View/Composers/Concerns/Extractable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Roots\Acorn\View\Concerns;
+namespace Roots\Acorn\View\Composers\Concerns;
 
 use Closure;
 use Illuminate\View\InvokableComponentVariable;
@@ -8,7 +8,7 @@ use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 
-trait ExtractsClassAsVariables
+trait Extractable
 {
     /**
      * The cache of public property names, keyed by class.

--- a/src/Roots/Acorn/View/Composers/Concerns/Extractable.php
+++ b/src/Roots/Acorn/View/Composers/Concerns/Extractable.php
@@ -8,6 +8,12 @@ use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
 
+/**
+ * Extract public properties from a composer to make available in a view. 
+ *
+ * @copyright Taylor Otwell
+ * @link https://github.com/illuminate/view/blob/v10.35.0/Component.php#L220-L342
+ */
 trait Extractable
 {
     /**

--- a/src/Roots/Acorn/View/Composers/Concerns/Extractable.php
+++ b/src/Roots/Acorn/View/Composers/Concerns/Extractable.php
@@ -9,7 +9,7 @@ use ReflectionMethod;
 use ReflectionProperty;
 
 /**
- * Extract public properties from a composer to make available in a view. 
+ * Extract public properties from a composer to make available in a view.
  *
  * @copyright Taylor Otwell
  * @link https://github.com/illuminate/view/blob/v10.35.0/Component.php#L220-L342

--- a/src/Roots/Acorn/View/Composers/Concerns/Extractable.php
+++ b/src/Roots/Acorn/View/Composers/Concerns/Extractable.php
@@ -12,6 +12,7 @@ use ReflectionProperty;
  * Extract public properties from a composer to make available in a view.
  *
  * @copyright Taylor Otwell
+ *
  * @link https://github.com/illuminate/view/blob/v10.35.0/Component.php#L220-L342
  */
 trait Extractable

--- a/src/Roots/Acorn/View/Concerns/ExtractsClassAsVariables.php
+++ b/src/Roots/Acorn/View/Concerns/ExtractsClassAsVariables.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Roots\Acorn\View\Concerns;
+
+use Closure;
+use Illuminate\View\InvokableComponentVariable;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
+
+trait ExtractsClassAsVariables
+{
+    /**
+     * The properties / methods that should not be exposed.
+     *
+     * @var array
+     */
+    protected $except = [];
+
+    /**
+     * The cache of public property names, keyed by class.
+     *
+     * @var array
+     */
+    protected static $propertyCache = [];
+
+    /**
+     * The cache of public method names, keyed by class.
+     *
+     * @var array
+     */
+    protected static $methodCache = [];
+
+    /**
+     * Extract the public properties for the class.
+     *
+     * @return array
+     */
+    protected function extractPublicProperties()
+    {
+        $class = get_class($this);
+
+        if (! isset(static::$propertyCache[$class])) {
+            $reflection = new ReflectionClass($this);
+
+            static::$propertyCache[$class] = collect($reflection->getProperties(ReflectionProperty::IS_PUBLIC))
+                ->reject(function (ReflectionProperty $property) {
+                    return $property->isStatic();
+                })
+                ->reject(function (ReflectionProperty $property) {
+                    return $this->shouldIgnore($property->getName());
+                })
+                ->map(function (ReflectionProperty $property) {
+                    return $property->getName();
+                })->all();
+        }
+
+        $values = [];
+
+        foreach (static::$propertyCache[$class] as $property) {
+            $values[$property] = $this->{$property};
+        }
+
+        return $values;
+    }
+
+    /**
+     * Extract the public methods for the class.
+     *
+     * @return array
+     */
+    protected function extractPublicMethods()
+    {
+        $class = get_class($this);
+
+        if (! isset(static::$methodCache[$class])) {
+            $reflection = new ReflectionClass($this);
+
+            static::$methodCache[$class] = collect($reflection->getMethods(ReflectionMethod::IS_PUBLIC))
+                ->reject(function (ReflectionMethod $method) {
+                    return $this->shouldIgnore($method->getName());
+                })
+                ->map(function (ReflectionMethod $method) {
+                    return $method->getName();
+                });
+        }
+
+        $values = [];
+
+        foreach (static::$methodCache[$class] as $method) {
+            $values[$method] = $this->createVariableFromMethod(new ReflectionMethod($this, $method));
+        }
+
+        return $values;
+    }
+
+    /**
+     * Create a callable variable from the given method.
+     *
+     * @return mixed
+     */
+    protected function createVariableFromMethod(ReflectionMethod $method)
+    {
+        return $method->getNumberOfParameters() === 0
+            ? $this->createInvokableVariable($method->getName())
+            : Closure::fromCallable([$this, $method->getName()]);
+    }
+
+    /**
+     * Create an invokable, toStringable variable for the given class method.
+     *
+     * @return \Illuminate\View\InvokableComponentVariable
+     */
+    protected function createInvokableVariable(string $method)
+    {
+        return new InvokableComponentVariable(function () use ($method) {
+            return $this->{$method}();
+        });
+    }
+
+    /**
+     * Determine if the given property / method should be ignored.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    protected function shouldIgnore($name)
+    {
+        return str_starts_with($name, '__') ||
+            in_array($name, $this->ignoredMethods());
+    }
+
+    /**
+     * Get the methods that should be ignored.
+     *
+     * @return array
+     */
+    protected function ignoredMethods()
+    {
+        return array_merge([
+            'views',
+            'compose',
+        ], $this->except);
+    }
+}

--- a/src/Roots/Acorn/View/Concerns/ExtractsClassAsVariables.php
+++ b/src/Roots/Acorn/View/Concerns/ExtractsClassAsVariables.php
@@ -11,13 +11,6 @@ use ReflectionProperty;
 trait ExtractsClassAsVariables
 {
     /**
-     * The properties / methods that should not be exposed.
-     *
-     * @var array
-     */
-    protected $except = [];
-
-    /**
      * The cache of public property names, keyed by class.
      *
      * @var array
@@ -137,9 +130,6 @@ trait ExtractsClassAsVariables
      */
     protected function ignoredMethods()
     {
-        return array_merge([
-            'views',
-            'compose',
-        ], $this->except);
+        return array_merge($this->defaultExcept, $this->except);
     }
 }

--- a/src/Roots/helpers.php
+++ b/src/Roots/helpers.php
@@ -11,7 +11,7 @@ use Roots\Acorn\Bootloader;
 /**
  * Get asset from manifest
  */
-function asset(string $asset, string $manifest = null): Asset
+function asset(string $asset, ?string $manifest = null): Asset
 {
     if (! $manifest) {
         return \app('assets.manifest')->asset($asset);
@@ -23,7 +23,7 @@ function asset(string $asset, string $manifest = null): Asset
 /**
  * Get bundle from manifest
  */
-function bundle(string $bundle, string $manifest = null): Bundle
+function bundle(string $bundle, ?string $manifest = null): Bundle
 {
     if (! $manifest) {
         return \app('assets.manifest')->bundle($bundle);
@@ -35,7 +35,7 @@ function bundle(string $bundle, string $manifest = null): Bundle
 /**
  * Instantiate the bootloader.
  */
-function bootloader(Application $app = null): Bootloader
+function bootloader(?Application $app = null): Bootloader
 {
     $bootloader = Bootloader::getInstance($app);
 

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -6,7 +6,7 @@ use Mockery;
 use Mockery\MockInterface;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
-function acorn_root(string $path = null)
+function acorn_root(?string $path = null)
 {
     return dirname(__DIR__).($path ? "/{$path}" : '');
 }
@@ -21,7 +21,7 @@ function plugin_entrypoint()
  *
  * @return string|TemporaryDirectory
  */
-function temp(string $path = null)
+function temp(?string $path = null)
 {
     static $temp;
 

--- a/tests/Test/Concerns/SupportsGlobalStubs.php
+++ b/tests/Test/Concerns/SupportsGlobalStubs.php
@@ -14,7 +14,7 @@ trait SupportsGlobalStubs
      * @param  string  $fn       The name of the global function
      * @param  null|callable  $callable The real function to monitor
      */
-    protected function stub(string $fn, callable $callable = null): MockeryCallableMock
+    protected function stub(string $fn, ?callable $callable = null): MockeryCallableMock
     {
         $script = <<<'DECLARE_FUNCTION'
         if (! function_exists('%1$s')) {


### PR DESCRIPTION
This gives Acorn's View Composers the same behavior as View Components exposing all public properties/methods automatically to the targeted view(s).

An added bonus to this is being able to easily invoke public methods using the variable inside a view such as `$example($post->ID)`.

Most code is taken from [Illuminate's Component.php](https://github.com/illuminate/view/blob/master/Component.php#L220-L342) and moved into a Trait.

This only takes effect when `with()` and `override()` are empty thus maintaining backwards compatibility.

Could use more testing.

## Change log

- ✨ Automatically expose public properties and methods on View Composers
- 💥 Change the `$ignore` property to `$except` in the View Composer `Arrayable` trait