### PR TITLE
🎨 Change variables/properties from snake_case to camelCase

### DIFF
--- a/bin/acorn
+++ b/bin/acorn
@@ -2,22 +2,22 @@
 <?php
 
 (static function () {
-    if (! is_file($autoload_path = dirname(__DIR__, 4) . '/vendor/autoload.php')) {
-        $autoload_path = dirname(__DIR__) . '/vendor/autoload.php';
+    if (! is_file($autoloadPath = dirname(__DIR__, 4) . '/vendor/autoload.php')) {
+        $autoloadPath = dirname(__DIR__) . '/vendor/autoload.php';
     }
     if (filter_input(INPUT_ENV, 'APPLICATION_PATH')) {
-        $autoload_path = filter_input(INPUT_ENV, 'APPLICATION_PATH') . '/vendor/autoload.php';
+        $autoloadPath = filter_input(INPUT_ENV, 'APPLICATION_PATH') . '/vendor/autoload.php';
     }
-    require_once $autoload_path;
+    require_once $autoloadPath;
 
-    $composer_path = (new Roots\Acorn\Filesystem\Filesystem)->closest(dirname($autoload_path, 2), 'composer.json');
+    $composerPath = (new Roots\Acorn\Filesystem\Filesystem)->closest(dirname($autoloadPath, 2), 'composer.json');
 
-    $root_path = dirname($composer_path);
+    $rootPath = dirname($composerPath);
 
-    $composer = json_decode(file_get_contents($composer_path), true);
+    $composer = json_decode(file_get_contents($composerPath), true);
 
     define('WP_USE_THEMES', false);
-    require_once "{$root_path}/{$composer['extra']['wordpress-install-dir']}/wp-blog-header.php";
+    require_once "{$rootPath}/{$composer['extra']['wordpress-install-dir']}/wp-blog-header.php";
 
     Roots\Acorn\Bootloader::getInstance()->boot();
 })();

--- a/bin/acorn
+++ b/bin/acorn
@@ -5,9 +5,11 @@
     if (! is_file($autoloadPath = dirname(__DIR__, 4) . '/vendor/autoload.php')) {
         $autoloadPath = dirname(__DIR__) . '/vendor/autoload.php';
     }
+
     if (filter_input(INPUT_ENV, 'APPLICATION_PATH')) {
         $autoloadPath = filter_input(INPUT_ENV, 'APPLICATION_PATH') . '/vendor/autoload.php';
     }
+
     require_once $autoloadPath;
 
     $composerPath = (new Roots\Acorn\Filesystem\Filesystem)->closest(dirname($autoloadPath, 2), 'composer.json');
@@ -17,6 +19,7 @@
     $composer = json_decode(file_get_contents($composerPath), true);
 
     define('WP_USE_THEMES', false);
+
     require_once "{$rootPath}/{$composer['extra']['wordpress-install-dir']}/wp-blog-header.php";
 
     Roots\Acorn\Bootloader::getInstance()->boot();

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,8 @@
   "config": {
     "sort-packages": true,
     "allow-plugins": {
-      "pestphp/pest-plugin": true
+      "pestphp/pest-plugin": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   },
   "minimum-stability": "dev",

--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -84,7 +84,7 @@ class Application extends FoundationApplication
      */
     public function usePaths(array $paths)
     {
-        $supported_paths = [
+        $supportedPaths = [
             'app' => 'appPath',
             'lang' => 'langPath',
             'config' => 'configPath',
@@ -95,14 +95,14 @@ class Application extends FoundationApplication
             'bootstrap' => 'bootstrapPath',
         ];
 
-        foreach ($paths as $path_type => $path) {
+        foreach ($paths as $pathType => $path) {
             $path = rtrim($path, '\\/');
 
-            if (! isset($supported_paths[$path_type])) {
-                throw new Exception("The {$path_type} path type is not supported.");
+            if (! isset($supportedPaths[$pathType])) {
+                throw new Exception("The {$pathType} path type is not supported.");
             }
 
-            $this->{$supported_paths[$path_type]} = $path;
+            $this->{$supportedPaths[$pathType]} = $path;
         }
 
         $this->bindPathsInContainer();
@@ -329,11 +329,11 @@ class Application extends FoundationApplication
             return $this->namespace;
         }
 
-        $composer = json_decode(file_get_contents($composer_path = $this->getAppComposer()), true);
+        $composer = json_decode(file_get_contents($composerPath = $this->getAppComposer()), true);
 
         foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path) {
             foreach ((array) $path as $pathChoice) {
-                if (realpath($this->path()) === realpath(dirname($composer_path).DIRECTORY_SEPARATOR.$pathChoice)) {
+                if (realpath($this->path()) === realpath(dirname($composerPath).DIRECTORY_SEPARATOR.$pathChoice)) {
                     return $this->namespace = $namespace;
                 }
             }

--- a/src/Roots/Acorn/Assets/Asset/Asset.php
+++ b/src/Roots/Acorn/Assets/Asset/Asset.php
@@ -9,35 +9,35 @@ use SplFileInfo;
 class Asset implements AssetContract
 {
     /**
-     * Local path
+     * The local asset path.
      *
      * @var string
      */
     protected $path;
 
     /**
-     * Remote URI
+     * The remote asset URI.
      *
      * @var string
      */
     protected $uri;
 
     /**
-     * MIME Content Type
+     * The asset MIME content type.
      *
      * @var string
      */
     protected $type;
 
     /**
-     * Base64-encoded contents
+     * The asset base64-encoded contents.
      *
      * @var string
      */
     protected $base64;
 
     /**
-     * Data URL of asset.
+     * The asset data URL.
      *
      * @var string
      */
@@ -86,17 +86,17 @@ class Asset implements AssetContract
     /**
      * Get the relative path to the asset.
      *
-     * @param  string  $base_path Base path to use for relative path.
+     * @param  string  $basePath Base path to use for relative path.
      */
-    public function relativePath(string $base_path): string
+    public function relativePath(string $basePath): string
     {
-        $base_path = rtrim($base_path, '/\\').'/';
+        $basePath = rtrim($basePath, '/\\').'/';
 
-        return (new Filesystem())->getRelativePath($base_path, $this->path());
+        return (new Filesystem())->getRelativePath($basePath, $this->path());
     }
 
     /**
-     * Base64-encoded contents
+     * Get the base64-encoded contents of the asset.
      *
      * @return string
      */
@@ -138,7 +138,7 @@ class Asset implements AssetContract
     }
 
     /**
-     * Get the MIME content type
+     * Get the MIME content type.
      *
      * @return string|false
      */
@@ -152,7 +152,7 @@ class Asset implements AssetContract
     }
 
     /**
-     * Get the MIME content type
+     * Get the MIME content type.
      *
      * @return string|false
      */

--- a/src/Roots/Acorn/Assets/AssetsServiceProvider.php
+++ b/src/Roots/Acorn/Assets/AssetsServiceProvider.php
@@ -39,6 +39,11 @@ class AssetsServiceProvider extends ServiceProvider
         }
     }
 
+    /**
+     * Get the default manifest.
+     *
+     * @return string
+     */
     protected function getDefaultManifest()
     {
         return $this->app['config']['assets.default'];

--- a/src/Roots/Acorn/Assets/Concerns/Enqueuable.php
+++ b/src/Roots/Acorn/Assets/Concerns/Enqueuable.php
@@ -55,8 +55,8 @@ trait Enqueuable
      */
     public function enqueueJs(bool|array $args = true, array $dependencies = [])
     {
-        $this->js(function ($handle, $src, $bundle_dependencies) use (&$dependencies, $args) {
-            $this->mergeDependencies($dependencies, $bundle_dependencies);
+        $this->js(function ($handle, $src, $bundleDependencies) use (&$dependencies, $args) {
+            $this->mergeDependencies($dependencies, $bundleDependencies);
 
             wp_enqueue_script($handle, $src, $dependencies, null, $args);
 
@@ -188,9 +188,9 @@ trait Enqueuable
      *
      * @return void
      */
-    protected function mergeDependencies(array &$dependencies, array ...$more_dependencies)
+    protected function mergeDependencies(array &$dependencies, array ...$moreDependencies)
     {
-        $dependencies = array_unique(array_merge($dependencies, ...$more_dependencies));
+        $dependencies = array_unique(array_merge($dependencies, ...$moreDependencies));
     }
 
     /**

--- a/src/Roots/Acorn/Assets/Manifest.php
+++ b/src/Roots/Acorn/Assets/Manifest.php
@@ -39,11 +39,6 @@ class Manifest implements ManifestContract
 
     /**
      * Create a new manifest instance.
-     *
-     * @param  string  $path
-     * @param  string  $uri
-     * @param  array  $assets
-     * @param  array|null  $bundles
      */
     public function __construct(string $path, string $uri, array $assets = [], array $bundles = null)
     {

--- a/src/Roots/Acorn/Assets/Manifest.php
+++ b/src/Roots/Acorn/Assets/Manifest.php
@@ -9,14 +9,42 @@ use Roots\Acorn\Assets\Contracts\Manifest as ManifestContract;
 
 class Manifest implements ManifestContract
 {
+    /**
+     * The manifest assets.
+     *
+     * @var array
+     */
     protected $assets;
 
+    /**
+     * The manifest bundles.
+     *
+     * @var array
+     */
     protected $bundles;
 
+    /**
+     * The manifest path.
+     *
+     * @var string
+     */
     protected $path;
 
+    /**
+     * The manifest URI.
+     *
+     * @var string
+     */
     protected $uri;
 
+    /**
+     * Create a new manifest instance.
+     *
+     * @param  string  $path
+     * @param  string  $uri
+     * @param  array  $assets
+     * @param  array|null  $bundles
+     */
     public function __construct(string $path, string $uri, array $assets = [], array $bundles = null)
     {
         $this->path = $path;
@@ -36,9 +64,10 @@ class Manifest implements ManifestContract
     public function asset($key): AssetContract
     {
         $key = $this->normalizeRelativePath($key);
-        $relative_path = $this->assets[$key] ?? $key;
-        $path = Str::before("{$this->path}/{$relative_path}", '?');
-        $uri = "{$this->uri}/{$relative_path}";
+        $relativePath = $this->assets[$key] ?? $key;
+
+        $path = Str::before("{$this->path}/{$relativePath}", '?');
+        $uri = "{$this->uri}/{$relativePath}";
 
         return AssetFactory::create($path, $uri);
     }

--- a/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
+++ b/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
@@ -19,7 +19,7 @@ class RootsBudMiddleware
      * @param  string|null  $devOrigin
      * @return void
      */
-    public function __construct(?string $dev_origin = null)
+    public function __construct(?string $devOrigin = null)
     {
         $this->devOrigin = $devOrigin;
     }

--- a/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
+++ b/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
@@ -7,15 +7,21 @@ use Illuminate\Support\Str;
 class RootsBudMiddleware
 {
     /**
-     * Dev server URI
+     * The Bud dev server origin header.
      *
      * @var string
      */
-    protected $dev_origin;
+    protected $devOrigin;
 
-    public function __construct(string $dev_origin = null)
+    /**
+     * Create a new Bud middleware instance.
+     *
+     * @param  string|null  $devOrigin
+     * @return void
+     */
+    public function __construct(string $devOrigin = null)
     {
-        $this->dev_origin = $dev_origin;
+        $this->devOrigin = $devOrigin;
     }
 
     /**
@@ -44,7 +50,7 @@ class RootsBudMiddleware
             return null;
         }
 
-        if (! $dev_origin_header = $this->getDevOriginHeader()) {
+        if (! $devOriginHeader = $this->getDevOriginHeader()) {
             return null;
         }
 
@@ -52,7 +58,7 @@ class RootsBudMiddleware
             return null;
         }
 
-        if (strstr($dev_origin_header, $dev->hostname) === false) {
+        if (strstr($devOriginHeader, $dev->hostname) === false) {
             return null;
         }
 
@@ -66,8 +72,8 @@ class RootsBudMiddleware
      */
     protected function getDevOriginHeader()
     {
-        return $this->dev_origin
-            ?: filter_input(INPUT_ENV, 'HTTP_X_BUD_DEV_ORIGIN', FILTER_SANITIZE_URL)
-            ?: filter_input(INPUT_SERVER, 'HTTP_X_BUD_DEV_ORIGIN', FILTER_SANITIZE_URL);
+        return $this->devOrigin
+            ?: filter_input(INPUT_ENV, 'HTTP_X_BUD_devOrigin', FILTER_SANITIZE_URL)
+            ?: filter_input(INPUT_SERVER, 'HTTP_X_BUD_devOrigin', FILTER_SANITIZE_URL);
     }
 }

--- a/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
+++ b/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
@@ -73,7 +73,7 @@ class RootsBudMiddleware
     protected function getDevOriginHeader()
     {
         return $this->devOrigin
-            ?: filter_input(INPUT_ENV, 'HTTP_X_BUD_devOrigin', FILTER_SANITIZE_URL)
-            ?: filter_input(INPUT_SERVER, 'HTTP_X_BUD_devOrigin', FILTER_SANITIZE_URL);
+            ?: filter_input(INPUT_ENV, 'HTTP_X_BUD_DEV_ORIGIN', FILTER_SANITIZE_URL)
+            ?: filter_input(INPUT_SERVER, 'HTTP_X_BUD_DEV_ORIGIN', FILTER_SANITIZE_URL);
     }
 }

--- a/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
+++ b/src/Roots/Acorn/Assets/Middleware/RootsBudMiddleware.php
@@ -16,7 +16,6 @@ class RootsBudMiddleware
     /**
      * Create a new Bud middleware instance.
      *
-     * @param  string|null  $devOrigin
      * @return void
      */
     public function __construct(?string $devOrigin = null)

--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -127,7 +127,7 @@ class Bootloader
     }
 
     /**
-     * Enable $_SERVER[HTTPS] in a console environment.
+     * Enable `$_SERVER[HTTPS]` in a console environment.
      *
      * @return void
      */
@@ -168,12 +168,12 @@ class Bootloader
         $kernel = $app->make(\Illuminate\Contracts\Console\Kernel::class);
         $kernel->bootstrap();
 
-        \WP_CLI::add_command('acorn', function ($args, $assoc_args) use ($kernel) {
+        \WP_CLI::add_command('acorn', function ($args, $assocArgs) use ($kernel) {
             $kernel->commands();
 
             $command = implode(' ', $args);
 
-            foreach ($assoc_args as $key => $value) {
+            foreach ($assocArgs as $key => $value) {
                 if ($key === 'interaction' && $value === false) {
                     $command .= ' --no-interaction';
 
@@ -225,7 +225,7 @@ class Bootloader
 
         add_filter(
             'do_parse_request',
-            fn ($do_parse, \WP $wp, $extra_query_vars) => apply_filters('acorn/router/do_parse_request', $do_parse, $wp, $extra_query_vars),
+            fn ($doParse, \WP $wp, $extraQueryVars) => apply_filters('acorn/router/do_parse_request', $doParse, $wp, $extraQueryVars),
             100,
             3
         );
@@ -305,11 +305,11 @@ class Bootloader
 
             defined('ACORN_BASEPATH') => constant('ACORN_BASEPATH'),
 
-            is_file($composer_path = get_theme_file_path('composer.json')) => dirname($composer_path),
+            is_file($composerPath = get_theme_file_path('composer.json')) => dirname($composerPath),
 
-            is_dir($app_path = get_theme_file_path('app')) => dirname($app_path),
+            is_dir($appPath = get_theme_file_path('app')) => dirname($appPath),
 
-            is_file($vendor_path = $this->files->closest(dirname(__DIR__, 4), 'composer.json')) => dirname($vendor_path),
+            is_file($vendorPath = $this->files->closest(dirname(__DIR__, 4), 'composer.json')) => dirname($vendorPath),
 
             default => dirname(__DIR__, 3)
         };

--- a/src/Roots/Acorn/Bootstrap/RegisterConsole.php
+++ b/src/Roots/Acorn/Bootstrap/RegisterConsole.php
@@ -30,7 +30,7 @@ class RegisterConsole
             return;
         }
 
-        WP_CLI::add_command('acorn', function ($args, $assoc_args) {
+        WP_CLI::add_command('acorn', function ($args, $assocArgs) {
             /** @var Kernel */
             $kernel = $this->app->make(Kernel::class);
 
@@ -38,7 +38,7 @@ class RegisterConsole
 
             $command = implode(' ', $args);
 
-            foreach ($assoc_args as $key => $value) {
+            foreach ($assocArgs as $key => $value) {
                 $command .= " {$this->formatOption($key, $value)}";
             }
 

--- a/src/Roots/Acorn/Console/Commands/AcornInitCommand.php
+++ b/src/Roots/Acorn/Console/Commands/AcornInitCommand.php
@@ -88,6 +88,7 @@ class AcornInitCommand extends Command
      * Execute the console command.
      *
      * @return void
+     *
      * @throws \Exception
      */
     public function handle()

--- a/src/Roots/Acorn/Console/Commands/AcornInitCommand.php
+++ b/src/Roots/Acorn/Console/Commands/AcornInitCommand.php
@@ -68,7 +68,7 @@ class AcornInitCommand extends Command
      *
      * @var string
      */
-    protected $base_path;
+    protected $basePath;
 
     /**
      * Create a new command instance.
@@ -84,16 +84,22 @@ class AcornInitCommand extends Command
         $this->files = $files;
     }
 
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     * @throws \Exception
+     */
     public function handle()
     {
-        $this->base_path = realpath($this->option('base') ?: $this->app->basePath());
+        $this->basePath = realpath($this->option('base') ?: $this->app->basePath());
 
-        if (! is_writable($this->base_path)) {
-            throw new Exception("The {$this->base_path} directory must be present and writable.");
+        if (! is_writable($this->basePath)) {
+            throw new Exception("The {$this->basePath} directory must be present and writable.");
         }
 
-        if ($this->base_path === dirname(__DIR__, 5)) {
-            throw new Exception("The {$this->base_path} directory is invalid. Specify an alternative using <comment>--base</comment> option.");
+        if ($this->basePath === dirname(__DIR__, 5)) {
+            throw new Exception("The {$this->basePath} directory is invalid. Specify an alternative using <comment>--base</comment> option.");
         }
 
         $paths = array_map('strtolower', array_intersect(
@@ -103,7 +109,7 @@ class AcornInitCommand extends Command
 
         foreach ($paths as $key) {
             if ($this->initPath($key, $path = $this->paths[$key])) {
-                $this->line("<info>Initialized</info> <comment>[{$this->base_path}/{$path}]</comment>");
+                $this->line("<info>Initialized</info> <comment>[{$this->basePath}/{$path}]</comment>");
             }
         }
     }
@@ -118,6 +124,13 @@ class AcornInitCommand extends Command
         return $this->defaults;
     }
 
+    /**
+     * Initialize the given path.
+     *
+     * @param  string  $key
+     * @param  string  $path
+     * @return bool
+     */
     protected function initPath($key, $path)
     {
         if (! $this->createPath($path)) {
@@ -143,12 +156,12 @@ class AcornInitCommand extends Command
      */
     protected function createPath($path)
     {
-        $this->files->ensureDirectoryExists("{$this->base_path}/{$path}", 0755, true);
+        $this->files->ensureDirectoryExists("{$this->basePath}/{$path}", 0755, true);
 
         if ($this->files->isDirectory($from = __DIR__."/stubs/paths/{$path}")) {
-            return $this->files->copyDirectory($from, "{$this->base_path}/{$path}");
+            return $this->files->copyDirectory($from, "{$this->basePath}/{$path}");
         }
 
-        return $this->files->isDirectory("{$this->base_path}/{$path}");
+        return $this->files->isDirectory("{$this->basePath}/{$path}");
     }
 }

--- a/src/Roots/Acorn/Console/Commands/VendorPublishCommand.php
+++ b/src/Roots/Acorn/Console/Commands/VendorPublishCommand.php
@@ -16,8 +16,8 @@ class VendorPublishCommand extends FoundationVendorPublishCommand
      */
     protected function publishItem($from, $to)
     {
-        if (Str::startsWith($to, $vendor_path = dirname(__DIR__, 5))) {
-            $to = str_replace($vendor_path, $this->getLaravel()->basePath(), $to);
+        if (Str::startsWith($to, $vendorPath = dirname(__DIR__, 5))) {
+            $to = str_replace($vendorPath, $this->getLaravel()->basePath(), $to);
 
             $this->callAcornInit($from, $to);
         }

--- a/src/Roots/Acorn/Filesystem/Filesystem.php
+++ b/src/Roots/Acorn/Filesystem/Filesystem.php
@@ -30,8 +30,8 @@ class Filesystem extends FilesystemBase
         $currentDirectory = $path;
 
         while ($this->isReadable($currentDirectory)) {
-            if ($this->isFile($file_path = $currentDirectory.DIRECTORY_SEPARATOR.$file)) {
-                return $file_path;
+            if ($this->isFile($filePath = $currentDirectory.DIRECTORY_SEPARATOR.$file)) {
+                return $filePath;
             }
 
             $parentDirectory = $this->dirname($currentDirectory);

--- a/src/Roots/Acorn/Providers/RouteServiceProvider.php
+++ b/src/Roots/Acorn/Providers/RouteServiceProvider.php
@@ -29,15 +29,15 @@ class RouteServiceProvider extends ServiceProvider
         $this->configureRateLimiting();
 
         $this->routes(function () {
-            if (is_file($api_routes = base_path('routes/api.php'))) {
+            if (is_file($api = base_path('routes/api.php'))) {
                 Route::middleware('api')
                     ->prefix('api')
-                    ->group($api_routes);
+                    ->group($api);
             }
 
-            if (is_file($web_routes = base_path('routes/web.php'))) {
+            if (is_file($web = base_path('routes/web.php'))) {
                 Route::middleware('web')
-                    ->group($web_routes);
+                    ->group($web);
             }
         });
     }

--- a/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
+++ b/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
@@ -54,10 +54,10 @@ trait FiltersTemplates
      *
      * @return string[] List of theme templates
      */
-    public function filterThemeTemplates($_templates, $_theme, $_post, $post_type)
+    public function filterThemeTemplates($templates, $theme, $post, $postType)
     {
-        return collect($_templates)
-            ->merge($this->getTemplates($post_type, $_theme->load_textdomain() ? $_theme->get('TextDomain') : ''))
+        return collect($templates)
+            ->merge($this->getTemplates($postType, $theme->load_textdomain() ? $theme->get('TextDomain') : ''))
             ->unique()
             ->toArray();
     }
@@ -70,33 +70,33 @@ trait FiltersTemplates
      * @see \WP_Theme::get_post_templates()
      * @link https://github.com/WordPress/WordPress/blob/5.8.1/wp-includes/class-wp-theme.php#L1203-L1221
      *
-     * @param  string  $post_type
-     * @param  string  $text_domain
+     * @param  string  $postType
+     * @param  string  $textDomain
      * @return string[]
      */
-    protected function getTemplates($post_type = '', $text_domain = '')
+    protected function getTemplates($postType = '', $textDomain = '')
     {
         if ($templates = wp_cache_get('acorn/post_templates', 'themes')) {
-            return $templates[$post_type] ?? [];
+            return $templates[$postType] ?? [];
         }
 
         $templates = [];
 
         foreach (array_reverse($this->fileFinder->getPaths()) as $path) {
             foreach (
-                array_filter($this->files->allFiles($path), fn ($file) => $file->getExtension() === 'php') as $full_path
+                array_filter($this->files->allFiles($path), fn ($file) => $file->getExtension() === 'php') as $fullPath
             ) {
-                if (! preg_match('|Template Name:(.*)$|mi', file_get_contents($full_path), $header)) {
+                if (! preg_match('|Template Name:(.*)$|mi', file_get_contents($fullPath), $header)) {
                     continue;
                 }
 
                 $types = ['page'];
 
-                if (preg_match('|Template Post Type:(.*)$|mi', file_get_contents($full_path), $type)) {
+                if (preg_match('|Template Post Type:(.*)$|mi', file_get_contents($fullPath), $type)) {
                     $types = explode(',', _cleanup_header_comment($type[1]));
                 }
 
-                $file = $this->files->getRelativePath("{$path}/", $full_path);
+                $file = $this->files->getRelativePath("{$path}/", $fullPath);
 
                 foreach ($types as $type) {
                     $type = sanitize_key($type);
@@ -110,16 +110,16 @@ trait FiltersTemplates
             }
         }
 
-        if ($text_domain) {
+        if ($textDomain) {
             foreach ($templates as $type => $files) {
                 foreach ($files as $file => $name) {
-                    $templates[$type][$file] = translate($name, $text_domain);
+                    $templates[$type][$file] = translate($name, $textDomain);
                 }
             }
         }
 
         wp_cache_add('acorn/post_templates', $templates, 'themes');
 
-        return $templates[$post_type] ?? [];
+        return $templates[$postType] ?? [];
     }
 }

--- a/src/Roots/Acorn/View/Composers/Concerns/AcfFields.php
+++ b/src/Roots/Acorn/View/Composers/Concerns/AcfFields.php
@@ -10,12 +10,12 @@ trait AcfFields
     /**
      * ACF data to be passed to the view before rendering.
      *
-     * @param  int  $post_id
+     * @param  int  $postId
      * @return array
      */
-    protected function fields($post_id = null)
+    protected function fields($postId = null)
     {
-        return collect(\get_fields($post_id))
+        return collect(\get_fields($postId))
             ->mapWithKeys(function ($value, $key) {
                 $value = is_array($value) ? new Fluent($value) : $value;
                 $method = Str::camel($key);

--- a/tests/Application/BootloaderTest.php
+++ b/tests/Application/BootloaderTest.php
@@ -32,34 +32,34 @@ it('should set the basePath if env var is set', function () {
 });
 
 it('should set the basePath if composer.json exists in theme', function () {
-    $composer_path = $this->fixture('base_path/base_composer');
+    $composerPath = $this->fixture('base_path/base_composer');
 
-    $this->stub('get_theme_file_path', fn ($path) => "{$composer_path}/{$path}");
+    $this->stub('get_theme_file_path', fn ($path) => "{$composerPath}/{$path}");
 
     $app = (new Bootloader)->getApplication();
 
-    expect($app->basePath())->toBe($composer_path);
+    expect($app->basePath())->toBe($composerPath);
 });
 
 it('should set the basePath if app exists in theme', function () {
-    $app_path = $this->fixture('base_path/base_app');
-    $this->stub('get_theme_file_path', fn () => $app_path);
+    $appPath = $this->fixture('base_path/base_app');
+    $this->stub('get_theme_file_path', fn () => $appPath);
 
     $app = Bootloader::getInstance()->getApplication();
 
-    expect($app->basePath())->toBe(dirname($app_path));
+    expect($app->basePath())->toBe(dirname($appPath));
 });
 
 it('should set the basePath if composer.json exists as ancestor of ../../../', function () {
     $files = mock(\Roots\Acorn\Filesystem\Filesystem::class);
     $this->stub('get_theme_file_path', fn () => '');
 
-    $composer_path = $this->fixture('base_path/base_composer');
+    $composerPath = $this->fixture('base_path/base_composer');
 
-    $files->shouldReceive('closest')->andReturn("{$composer_path}/composer.json");
+    $files->shouldReceive('closest')->andReturn("{$composerPath}/composer.json");
     $files->shouldReceive('ensureDirectoryExists');
 
     $app = (new Bootloader(null, $files))->getApplication();
 
-    expect($app->basePath())->toBe($composer_path);
+    expect($app->basePath())->toBe($composerPath);
 });


### PR DESCRIPTION
This was mainly to change snake_case variables/properties to camelCase but I cleaned up some other stuff along the way.

Ideally this should make vars/prop naming conventions uniform with Laravel and the rest of the Acorn codebase. I don't think this PR has any breaking changes but there will be a second PR for the View Composer `Cacheable` trait which will have a small one if the default properties were modified.

## Change log

- 🎨 Change variables/properties from snake_case to camelCase
- 📝 Improve docblocks
- 📝 Add missing docblocks