### PR TITLE
🎨 Remove `with()` from the composer stub

### DIFF
--- a/src/Roots/Acorn/Console/Commands/stubs/composer.stub
+++ b/src/Roots/Acorn/Console/Commands/stubs/composer.stub
@@ -14,16 +14,4 @@ class DummyClass extends Composer
     protected static $views = [
         DummyViews
     ];
-
-    /**
-     * Data to be passed to view before rendering.
-     *
-     * @return array
-     */
-    public function with()
-    {
-        return [
-            //
-        ];
-    }
 }


### PR DESCRIPTION
This is no longer necessary with #320 