### PR TITLE
Fix: Allow 4** HTTP responses to be rendered normally by router

### DIFF
--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -240,10 +240,6 @@ class Bootloader
             /** @var \Illuminate\Http\Response */
             $response = $kernel->handle($request);
 
-            if (! $response->isServerError() && $response->status() >= 400) {
-                return;
-            }
-
             $body = $response->send();
 
             $kernel->terminate($request, $body);


### PR DESCRIPTION
Filtering out 4** status codes from the router responses seems unreasonable, it for example stops the returning of 401 Bad Request responses.

Fixes #288