### PR TITLE
Fix: Fixed issue with symlinked theme breaking view finding.

### DIFF
--- a/src/Roots/Acorn/Sage/ViewFinder.php
+++ b/src/Roots/Acorn/Sage/ViewFinder.php
@@ -41,7 +41,7 @@ class ViewFinder
     {
         $this->finder = $finder;
         $this->files = $files;
-        $this->path = $path ? realpath($path) : get_theme_file_path();
+        $this->path = realpath($path ?: get_theme_file_path());
     }
 
     /**


### PR DESCRIPTION
Makes sure the `get_theme_file_path()` result is also put through `realpath`, so symlinked paths are resolved.
This fixes #287 