### PR TITLE
Fix: response() returning ResponseFactory instead of Response

### DIFF
--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -230,7 +230,7 @@ class Bootloader
         $app->make('router')
             ->any('{any?}', fn () => tap(response(''), function (Response $response) {
                 foreach (headers_list() as $header) {
-                    if (!headers_sent()) {
+                    if (! headers_sent()) {
                         header_remove($header);
                     }
                     $response->header(...explode(': ', $header));

--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -228,9 +228,11 @@ class Bootloader
     protected function registerWordPressRoute(ApplicationContract $app)
     {
         $app->make('router')
-            ->any('{any?}', fn () => tap(response(), function (Response $response) {
+            ->any('{any?}', fn () => tap(response(''), function (Response $response) {
                 foreach (headers_list() as $header) {
-                    header_remove($header);
+                    if (!headers_sent()) {
+                        header_remove($header);
+                    }
                     $response->header(...explode(': ', $header));
                 }
 


### PR DESCRIPTION
This PR attempts to resolve issue #335, which involves an exception occurring in the new WordPress Routes support introduced in #334. 

Previously, when `response()` was called without any parameters, it would return `ResponseFactory::class` because of a [conditional check](https://github.com/roots/acorn/blob/9de4924933dc1e382576eff3b598287f102e232c/src/Illuminate/Foundation/helpers.php#L792). However, to obtain the required `Response::class`, an empty string now needs to be passed.

Furthermore, this pull request includes a check to prevent errors with `header_remove()` by verifying if headers have already been sent.
