### PR TITLE
🐛 Bootloader: Bail early on `wp-login.php`/`wp-admin`, and some other `/wp-` requests

### DIFF
--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -261,12 +261,12 @@ class Bootloader
         ?\Illuminate\Routing\Route $route,
         array $config
     ) {
-        if (
-            strpos($request->getRequestUri(), '/wp-comments-post.php') !== false ||
-            strpos($request->getRequestUri(), '/wp-login.php') !== false ||
-            strpos($request->getRequestUri(), '/wp-signup.php') !== false ||
-            strpos($request->getRequestUri(), '/wp-admin/') !== false
-        ) {
+        if (Str::contains($request->getRequestUri(), [
+            '/wp-comments-post.php',
+            '/wp-login.php',
+            '/wp-signup.php',
+            '/wp-admin/',
+        ])) {
             return; // Let WordPress handle these requests
         }
 

--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -261,10 +261,14 @@ class Bootloader
         ?\Illuminate\Routing\Route $route,
         array $config
     ) {
-        if (strpos($request->getRequestUri(), '/wp-login.php') !== false) {
+        if (
+            strpos($request->getRequestUri(), '/wp-comments-post.php') !== false ||
+            strpos($request->getRequestUri(), '/wp-login.php') !== false ||
+            strpos($request->getRequestUri(), '/wp-signup.php') !== false ||
+            strpos($request->getRequestUri(), '/wp-admin/') !== false
+        ) {
             add_filter('do_parse_request', '__return_false', 100, 3);
-
-            return;
+            return; // Let WordPress handle these requests
         }
 
         add_filter('do_parse_request', function ($doParse, \WP $wp, $extraQueryVars) use ($route) {

--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -262,9 +262,7 @@ class Bootloader
         array $config
     ) {
         if (strpos($request->getRequestUri(), '/wp-login.php') !== false) {
-            add_filter('do_parse_request', function ($doParse, \WP $wp, $extraQueryVars) {
-                return false;
-            }, 100, 3);
+            add_filter('do_parse_request', '__return_false', 100, 3);
 
             return;
         }

--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -261,6 +261,14 @@ class Bootloader
         ?\Illuminate\Routing\Route $route,
         array $config
     ) {
+        if (strpos($request->getRequestUri(), '/wp-login.php') !== false) {
+            add_filter('do_parse_request', function ($doParse, \WP $wp, $extraQueryVars) {
+                return false;
+            }, 100, 3);
+
+            return;
+        }
+
         add_filter('do_parse_request', function ($doParse, \WP $wp, $extraQueryVars) use ($route) {
             if (! $route) {
                 return $doParse;

--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -267,7 +267,6 @@ class Bootloader
             strpos($request->getRequestUri(), '/wp-signup.php') !== false ||
             strpos($request->getRequestUri(), '/wp-admin/') !== false
         ) {
-            add_filter('do_parse_request', '__return_false', 100, 3);
             return; // Let WordPress handle these requests
         }
 


### PR DESCRIPTION
* [x] Fix wp-login.php
* [x] Fix wp-admin / admin-ajax.php requests
* [x] Fix other requests? wp-comments-post.php, wp-signup.php?

Fix #337