### PR TITLE
Fix `is_file()` deprecation warning

### DIFF
--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -373,7 +373,7 @@ class Bootloader
      */
     protected function environmentPath(): string
     {
-        return is_file($envPath = $this->files->closest($this->basePath(), '.env'))
+        return is_file($envPath = $this->files->closest($this->basePath(), '.env') ?? '')
             ? dirname($envPath)
             : $this->basePath();
     }


### PR DESCRIPTION
Using Sage on vanilla WP, you'll receive the following notice due to `Filesystem::closest` returning `null` because there's no `.env` to be found.

```
Deprecated: is_file(): Passing null to parameter #1 ($filename) of type string is deprecated in /vendor/roots/acorn/src/Roots/Acorn/Bootloader.php on line 376
```
