### PR TITLE
fix: Deprecations in CI action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout the project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup the PHP ${{ matrix.php }} environment on ${{ runner.os }}
         uses: shivammathur/setup-php@v2
@@ -28,11 +28,11 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
         env:
-          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore the Composer cache directory
         id: composercache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         id: composercache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}


### PR DESCRIPTION
# This PR Fixes
* Upgrade `actions/checkout` to v4.
* Upgrade `actions/cache` to v3.
* Replace: deprecated `COMPOSER_TOKEN` variable in favor of `GITHUB_TOKEN`
* fix: The set-output command is deprecated and will be disabled soon.

<img width="857" alt="Screenshot 2024-02-02 at 7 09 32 PM" src="https://github.com/roots/acorn/assets/6929121/040b483d-3fb4-4ce0-a289-1c6fa2583c19">
<img width="1118" alt="Screenshot 2024-02-02 at 7 13 03 PM" src="https://github.com/roots/acorn/assets/6929121/3e67031c-24d4-4f4c-a064-760cdd976b73">
