### PR TITLE
Replace deprecated CORS config identifier class with HandleCors middleware

### DIFF
--- a/src/Roots/Acorn/Providers/AcornServiceProvider.php
+++ b/src/Roots/Acorn/Providers/AcornServiceProvider.php
@@ -21,7 +21,7 @@ class AcornServiceProvider extends ServiceProvider
      * @var string[]
      */
     protected $providerConfigs = [
-        \Fruitcake\Cors\CorsServiceProvider::class => 'cors',
+        \Illuminate\Http\Middleware\HandleCors::class => 'cors',
         \Illuminate\Auth\AuthServiceProvider::class => 'auth',
         \Illuminate\Broadcasting\BroadcastServiceProvider::class => 'broadcasting',
         \Illuminate\Cache\CacheServiceProvider::class => 'cache',

--- a/src/Roots/Acorn/Providers/AcornServiceProvider.php
+++ b/src/Roots/Acorn/Providers/AcornServiceProvider.php
@@ -21,7 +21,6 @@ class AcornServiceProvider extends ServiceProvider
      * @var string[]
      */
     protected $providerConfigs = [
-        \Illuminate\Http\Middleware\HandleCors::class => 'cors',
         \Illuminate\Auth\AuthServiceProvider::class => 'auth',
         \Illuminate\Broadcasting\BroadcastServiceProvider::class => 'broadcasting',
         \Illuminate\Cache\CacheServiceProvider::class => 'cache',


### PR DESCRIPTION
Since the `fruitcake/laravel-cors` is [deprecated since Laravel 9.x](https://github.com/laravel/laravel/pull/5825/files), we should replace the config identifier with the core one (`\Illuminate\Http\Middleware\HandleCors`).