### PR TITLE
Add `wp-cron.php` to exclusion list for request handler

### DIFF
--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -263,6 +263,7 @@ class Bootloader
     ) {
         if (Str::contains($request->getRequestUri(), [
             '/wp-comments-post.php',
+            '/wp-cron.php',
             '/wp-login.php',
             '/wp-signup.php',
             '/wp-admin/',


### PR DESCRIPTION
This PR includes ﻿`wp-cron.php` request in the exclusion list for the request handler introduced in #339.