### PR TITLE
fix: Let WP handle requests that should trigger a canonical redirect

### DIFF
--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -270,6 +270,10 @@ class Bootloader
             return; // Let WordPress handle these requests
         }
 
+        if (redirect_canonical(null, false)) {
+            return; // Let WordPress handle these requests
+        }
+
         add_filter('do_parse_request', function ($doParse, \WP $wp, $extraQueryVars) use ($route) {
             if (! $route) {
                 return $doParse;


### PR DESCRIPTION
The `registerRequestHandler()` method should let WordPress handle request that will result in a canonical redirect.

see https://github.com/roots/acorn/issues/342