### PR TITLE
Prevent with() and override() from being triggered twice on merge

### DIFF
--- a/src/Roots/Acorn/View/Composer.php
+++ b/src/Roots/Acorn/View/Composer.php
@@ -90,11 +90,9 @@ abstract class Composer
      */
     protected function merge()
     {
+        [$with, $override] = [$this->with(), $this->override()];
 
-        $withOutcome = $this->with();
-        $overrideOutcome = $this->override();
-        
-        if (! $withOutcome && ! $overrideOutcome) {
+        if (! $with && ! $override) {
             return array_merge(
                 $this->extractPublicProperties(),
                 $this->extractPublicMethods(),
@@ -103,9 +101,9 @@ abstract class Composer
         }
 
         return array_merge(
-            $withOutcome,
+            $with,
             $this->view->getData(),
-            $overrideOutcome
+            $override
         );
     }
 

--- a/src/Roots/Acorn/View/Composer.php
+++ b/src/Roots/Acorn/View/Composer.php
@@ -90,7 +90,11 @@ abstract class Composer
      */
     protected function merge()
     {
-        if (! $this->with() && ! $this->override()) {
+
+        $withOutcome = $this->with();
+        $overrideOutcome = $this->override();
+        
+        if (! $withOutcome && ! $overrideOutcome) {
             return array_merge(
                 $this->extractPublicProperties(),
                 $this->extractPublicMethods(),
@@ -99,9 +103,9 @@ abstract class Composer
         }
 
         return array_merge(
-            $this->with(),
+            $withOutcome,
             $this->view->getData(),
-            $this->override()
+            $overrideOutcome
         );
     }
 


### PR DESCRIPTION
Store the outcome of with() and override() in variables instead of risking them being executing twice.