### PR TITLE
Add `guzzlehttp/guzzle` to fix Laravel HTTP client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     "php": ">=8.1",
     "ext-json": "*",
     "ext-mbstring": "*",
+    "guzzlehttp/guzzle": "^7.8",
     "illuminate/cache": "^10.43",
     "illuminate/config": "^10.43",
     "illuminate/console": "^10.43",


### PR DESCRIPTION
The [guzzlehttp/guzzle](https://github.com/guzzle/guzzle) package is required to use the [HTTP Client](https://laravel.com/docs/10.x/http-client) available in Laravel. Without this, attempting to use it fails while showing no LSP or runtime errors.

This PR simply adds the package to Acorn's composer file.

Discussion: https://discourse.roots.io/t/26776