### PR TITLE
🩹 Always register the default route

### DIFF
--- a/src/Roots/Acorn/Bootloader.php
+++ b/src/Roots/Acorn/Bootloader.php
@@ -186,9 +186,7 @@ class Bootloader
 
         $kernel->bootstrap($request);
 
-        if ($this->shouldHandleDefaultRequest()) {
-            $this->registerDefaultRoute();
-        }
+        $this->registerDefaultRoute();
 
         try {
             $route = $this->app->make('router')->getRoutes()->match($request);


### PR DESCRIPTION
I added a conditional to check for `shouldHandleDefaultRequest()` before registering the default WordPress route in #356 but it is unnecessary and breaks custom routes (or at least Livewire, in my testing).