### PR TITLE
🔨 refactor(manifest): Throw custom error when bundle is not found in manifest

### DIFF
--- a/src/Roots/Acorn/Assets/Exceptions/BundleNotFoundException.php
+++ b/src/Roots/Acorn/Assets/Exceptions/BundleNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Roots\Acorn\Assets\Exceptions;
+
+use Exception;
+
+class BundleNotFoundException extends Exception
+{
+    //
+}

--- a/src/Roots/Acorn/Assets/Manifest.php
+++ b/src/Roots/Acorn/Assets/Manifest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Str;
 use Roots\Acorn\Assets\Contracts\Asset as AssetContract;
 use Roots\Acorn\Assets\Contracts\Bundle as BundleContract;
 use Roots\Acorn\Assets\Contracts\Manifest as ManifestContract;
+use Roots\Acorn\Assets\Exceptions\BundleNotFoundException;
 
 class Manifest implements ManifestContract
 {
@@ -71,9 +72,14 @@ class Manifest implements ManifestContract
      * Get specified bundles.
      *
      * @param  string  $key
+     *
+     * @throws \Roots\Acorn\Assets\Exceptions\BundleNotFoundException
      */
     public function bundle($key): BundleContract
     {
+        if (! isset($this->bundles[$key])) {
+            throw new BundleNotFoundException("Bundle [{$key}] not found in manifest.");
+        }
         return new Bundle($key, $this->bundles[$key], $this->path, $this->uri);
     }
 

--- a/src/Roots/Acorn/Assets/Manifest.php
+++ b/src/Roots/Acorn/Assets/Manifest.php
@@ -80,6 +80,7 @@ class Manifest implements ManifestContract
         if (! isset($this->bundles[$key])) {
             throw new BundleNotFoundException("Bundle [{$key}] not found in manifest.");
         }
+
         return new Bundle($key, $this->bundles[$key], $this->path, $this->uri);
     }
 


### PR DESCRIPTION
I often get the general `Undefined array key "fonts"` exception when trying to enqueue a bundle before adding it to my `bud.config.js`. This PR replaces that general exception with a custom `BundleNotFoundException` with a more vebose message `Bundle [fonts] not found in manifest`,