### PR TITLE
🧑‍💻 Reverse the template hierarchy when the theme supports `block-templates`

### DIFF
--- a/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
+++ b/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
@@ -14,7 +14,11 @@ trait FiltersTemplates
      */
     public function filterTemplateHierarchy($files)
     {
-        return [...$this->sageFinder->locate($files), ...$files];
+        $templates = [...$this->sageFinder->locate($files), ...$files];
+
+        return ! get_theme_support('block-templates')
+            ? $templates
+            : array_reverse($templates);
     }
 
     /**


### PR DESCRIPTION
This will make FSE templates take priority over Blade when `block-templates` are supported on the theme. 

This should make FSE support a little more seamless.