### PR TITLE
✨ Add editor style support to `bundle()`

### DIFF
--- a/src/Roots/Acorn/Assets/Concerns/Enqueuable.php
+++ b/src/Roots/Acorn/Assets/Concerns/Enqueuable.php
@@ -79,6 +79,18 @@ trait Enqueuable
     }
 
     /**
+     * Add CSS files as editor styles in WordPress.
+     *
+     * @return $this
+     */
+    public function editorStyles()
+    {
+        $this->css(fn ($handle, $src) => add_editor_style($src));
+
+        return $this;
+    }
+
+    /**
      * Dequeue CSS files in WordPress.
      *
      * @return $this

--- a/tests/Assets/BundleTest.php
+++ b/tests/Assets/BundleTest.php
@@ -42,6 +42,15 @@ it('can enqueue css', function () {
     $app->enqueueCss();
 });
 
+it('can add editor styles', function () {
+    $manifest = json_decode(file_get_contents($this->fixture('bud_single_runtime/public/entrypoints.json')), JSON_OBJECT_AS_ARRAY);
+    $app = new Bundle('app', $manifest['app'], $this->fixture('bud_single_runtime'), 'https://k.jo');
+
+    $this->stub('add_editor_style', fn (...$args) => assertMatchesSnapshot($args));
+
+    $app->editorStyles();
+});
+
 it('can dequeue css', function () {
     $manifest = json_decode(file_get_contents($this->fixture('bud_single_runtime/public/entrypoints.json')), JSON_OBJECT_AS_ARRAY);
     $app = new Bundle('app', $manifest['app'], $this->fixture('bud_single_runtime'), 'https://k.jo');

--- a/tests/__snapshots__/BundleTest__it_can_add_editor_styles__1.yml
+++ b/tests/__snapshots__/BundleTest__it_can_add_editor_styles__1.yml
@@ -1,0 +1,1 @@
+- 'https://k.jo/public/app.2.4476c5f869ee7584ba3c.css'


### PR DESCRIPTION
This adds `bundle($style)->editorStyles()` to simplify adding editor styles.

ref: https://github.com/roots/acorn-fse-helper/issues/1#issuecomment-2026311655