### PR TITLE
🩹 Only prioritize block templates in block themes

### DIFF
--- a/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
+++ b/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
@@ -24,18 +24,18 @@ trait FiltersTemplates
             return [...$templates, ...$files];
         }
 
-        $paths = [];
+        $pages = [];
 
         if ($template = get_page_template_slug()) {
-            $paths = array_filter(
+            $pages = array_filter(
                 $templates,
                 fn ($file) => str_contains($file, $template)
             );
 
-            $templates = array_diff($templates, $paths);
+            $templates = array_diff($templates, $pages);
         }
 
-        return [...$paths, ...$files, ...$templates];
+        return [...$pages, ...$files, ...$templates];
     }
 
     /**

--- a/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
+++ b/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
@@ -14,9 +14,28 @@ trait FiltersTemplates
      */
     public function filterTemplateHierarchy($files)
     {
-        return wp_is_block_theme() && current_theme_supports('block-templates')
-            ? [...$files, ...$this->sageFinder->locate($files)]
-            : [...$this->sageFinder->locate($files), ...$files];
+        $templates = $this->sageFinder->locate($files);
+
+        if (
+            ! function_exists('wp_is_block_theme') ||
+            ! wp_is_block_theme() ||
+            ! current_theme_supports('block-templates')
+        ) {
+            return [...$templates, ...$files];
+        }
+
+        $paths = [];
+
+        if ($template = get_page_template_slug()) {
+            $paths = array_filter(
+                $templates,
+                fn ($file) => str_contains($file, $template)
+            );
+
+            $templates = array_diff($templates, $paths);
+        }
+
+        return [...$paths, ...$files, ...$templates];
     }
 
     /**

--- a/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
+++ b/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
@@ -14,11 +14,9 @@ trait FiltersTemplates
      */
     public function filterTemplateHierarchy($files)
     {
-        $templates = [...$this->sageFinder->locate($files), ...$files];
-
-        return ! current_theme_supports('block-templates')
-            ? $templates
-            : array_reverse($templates);
+        return wp_is_block_theme() && current_theme_supports('block-templates')
+            ? [...$files, ...$this->sageFinder->locate($files)]
+            : [...$this->sageFinder->locate($files), ...$files];
     }
 
     /**


### PR DESCRIPTION
Block templates should only be prioritized when there is a `index.html` (see: https://developer.wordpress.org/reference/classes/wp_theme/is_block_theme/)

Fixes potential issues like https://discourse.roots.io/t/acorn-v4-1-1-released/26905/2