### PR TITLE
✨ Add `acorn:install` command to simplify installing Acorn

### DIFF
--- a/src/Roots/Acorn/Console/Commands/AcornInstallCommand.php
+++ b/src/Roots/Acorn/Console/Commands/AcornInstallCommand.php
@@ -14,8 +14,8 @@ class AcornInstallCommand extends Command
      * @var string
      */
     protected $signature = 'acorn:install
-                            {--init : Initialize Acorn}
-                            {--autoload : Install the Acorn autoload dump script}';
+                            {--autoload : Install the Acorn autoload dump script}
+                            {--init : Initialize Acorn}';
 
     /**
      * The console command description.
@@ -41,6 +41,10 @@ class AcornInstallCommand extends Command
      */
     protected function askToInstallScript(): void
     {
+        if (! $this->option('autoload') && $this->option('no-interaction')) {
+            return;
+        }
+
         if ($this->option('autoload') || confirm(
             label: 'Would you like to install the Acorn autoload dump script?',
             default: true,
@@ -90,6 +94,10 @@ class AcornInstallCommand extends Command
      */
     protected function askToInitialize(): void
     {
+        if (! $this->option('init') && $this->option('no-interaction')) {
+            return;
+        }
+
         if ($this->option('init') || confirm(
             label: 'Would you like to initialize Acorn?',
             default: true,

--- a/src/Roots/Acorn/Console/Commands/AcornInstallCommand.php
+++ b/src/Roots/Acorn/Console/Commands/AcornInstallCommand.php
@@ -79,8 +79,8 @@ class AcornInstallCommand extends Command
         $configuration['scripts']['post-autoload-dump'][] = $script;
 
         $configuration = str(json_encode($configuration, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES))
-            ->append(PHP_EOL)
             ->replace('    ', '  ')
+            ->append(PHP_EOL)
             ->toString();
 
         file_put_contents(

--- a/src/Roots/Acorn/Console/Commands/AcornInstallCommand.php
+++ b/src/Roots/Acorn/Console/Commands/AcornInstallCommand.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Roots\Acorn\Console\Commands;
+
+use Composer\InstalledVersions;
+
+use function Laravel\Prompts\confirm;
+
+class AcornInstallCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'acorn:install
+                            {--init : Initialize Acorn}
+                            {--autoload : Install the Acorn autoload dump script}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install Acorn into the application';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->askToInstallScript();
+        $this->askToInitialize();
+        $this->askToStar();
+
+        return static::SUCCESS;
+    }
+
+    /**
+     * Install the Acorn autoload dump script.
+     */
+    protected function askToInstallScript(): void
+    {
+        if ($this->option('autoload') || confirm(
+            label: 'Would you like to install the Acorn autoload dump script?',
+            default: true,
+        )) {
+            $this->installAutoloadDump();
+        }
+    }
+
+    /**
+     * Install the Acorn autoload dump script.
+     */
+    protected function installAutoloadDump(): void
+    {
+        $path = InstalledVersions::getInstallPath('roots/acorn');
+        $path = dirname($path, 5);
+
+        $composer = "{$path}/composer.json";
+
+        if (! file_exists($composer)) {
+            return;
+        }
+
+        $configuration = json_decode(file_get_contents($composer), associative: true);
+
+        $script = 'Roots\\Acorn\\ComposerScripts::postAutoloadDump';
+
+        if (in_array($script, $configuration['scripts']['post-autoload-dump'] ?? [])) {
+            return;
+        }
+
+        $configuration['scripts']['post-autoload-dump'] ??= [];
+        $configuration['scripts']['post-autoload-dump'][] = $script;
+
+        $configuration = str(json_encode($configuration, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES))
+            ->append(PHP_EOL)
+            ->replace('    ', '  ')
+            ->toString();
+
+        file_put_contents(
+            $composer,
+            $configuration,
+        );
+    }
+
+    /**
+     * Ask the user to initialize Acorn.
+     */
+    protected function askToInitialize(): void
+    {
+        if ($this->option('init') || confirm(
+            label: 'Would you like to initialize Acorn?',
+            default: true,
+        )) {
+            $this->callSilent('acorn:init', ['--base' => $this->getLaravel()->basePath()]);
+        }
+    }
+
+    /**
+     * Ask the user to star the Acorn repository.
+     */
+    protected function askToStar(): void
+    {
+        if ($this->option('no-interaction')) {
+            return;
+        }
+
+        if (confirm(
+            label: '🎉 All done! Would you like to show some love by starring the Acorn repo on GitHub?',
+            default: true,
+        )) {
+            match (PHP_OS_FAMILY) {
+                'Darwin' => exec('open https://github.com/roots/acorn'),
+                'Linux' => exec('xdg-open https://github.com/roots/acorn'),
+                'Windows' => exec('start https://github.com/roots/acorn'),
+            };
+
+            $this->components->info('Thank you!');
+        }
+    }
+}

--- a/src/Roots/Acorn/Console/Commands/AcornInstallCommand.php
+++ b/src/Roots/Acorn/Console/Commands/AcornInstallCommand.php
@@ -37,7 +37,7 @@ class AcornInstallCommand extends Command
     }
 
     /**
-     * Install the Acorn autoload dump script.
+     * Ask to install the Acorn autoload dump script.
      */
     protected function askToInstallScript(): void
     {

--- a/src/Roots/Acorn/Console/Commands/AcornInstallCommand.php
+++ b/src/Roots/Acorn/Console/Commands/AcornInstallCommand.php
@@ -108,7 +108,7 @@ class AcornInstallCommand extends Command
         }
 
         if (confirm(
-            label: '🎉 All done! Would you like to show some love by starring the Acorn repo on GitHub?',
+            label: '🎉 All done! Would you like to show love by starring Acorn on GitHub?',
             default: true,
         )) {
             match (PHP_OS_FAMILY) {

--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -34,6 +34,7 @@ class Kernel extends FoundationConsoleKernel
         \Illuminate\Routing\Console\MiddlewareMakeCommand::class,
         \Roots\Acorn\Console\Commands\AboutCommand::class,
         \Roots\Acorn\Console\Commands\AcornInitCommand::class,
+        \Roots\Acorn\Console\Commands\AcornInstallCommand::class,
         \Roots\Acorn\Console\Commands\ComposerMakeCommand::class,
         \Roots\Acorn\Console\Commands\ConfigCacheCommand::class,
         \Roots\Acorn\Console\Commands\KeyGenerateCommand::class,


### PR DESCRIPTION
This adds an `acorn:install` command to simplify installing the Acorn `post-autoload-dump` script as well as asking the user if they want to initialize Acorn with `acorn:init`.

![Screenshot](https://i.imgur.com/n6PK7Y5.png)