### PR TITLE
🩹 Fix duplicate provider registration

### DIFF
--- a/src/Roots/Acorn/DefaultProviders.php
+++ b/src/Roots/Acorn/DefaultProviders.php
@@ -35,6 +35,7 @@ class DefaultProviders extends DefaultProvidersBase
             ->filter(fn ($provider) => ! str_contains($provider, 'Illuminate\\Foundation\\'))
             ->push('Illuminate\\Foundation\\Providers\\ComposerServiceProvider')
             ->push('Illuminate\\Database\\MigrationServiceProvider')
+            ->unique()
             ->all();
     }
 }

--- a/tests/Application/DefaultProvidersTest.php
+++ b/tests/Application/DefaultProvidersTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Roots\Acorn\Tests\Test\Stubs\BootableServiceProvider;
+use Roots\Acorn\Tests\Test\TestCase;
+
+uses(TestCase::class);
+
+it('dedupes registered providers', function () {
+    $providers = \Roots\Acorn\ServiceProvider::defaultProviders()->merge([
+        BootableServiceProvider::class,
+        BootableServiceProvider::class,
+    ]);
+
+    expect($providers->toArray())->toBe(array_unique($providers->toArray()));
+});


### PR DESCRIPTION
Noticed while working on #370 that providers are getting duplicated in the `provider.php` cache. This fixes it.