### PR TITLE
Feat: Add Laravel queue support

### DIFF
--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -5,6 +5,8 @@ namespace Roots\Acorn\Console;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Console\Kernel as FoundationConsoleKernel;
+use Illuminate\Queue\Console\WorkCommand;
+use Illuminate\Queue\Worker;
 
 class Kernel extends FoundationConsoleKernel
 {
@@ -14,6 +16,7 @@ class Kernel extends FoundationConsoleKernel
      * @var array
      */
     protected $commands = [
+        \Illuminate\Queue\Console\WorkCommand::class,
         \Illuminate\Cache\Console\ClearCommand::class,
         \Illuminate\Cache\Console\ForgetCommand::class,
         \Illuminate\Database\Console\DbCommand::class,
@@ -28,6 +31,7 @@ class Kernel extends FoundationConsoleKernel
         \Illuminate\Foundation\Console\ProviderMakeCommand::class,
         \Illuminate\Foundation\Console\RouteClearCommand::class,
         \Illuminate\Foundation\Console\RouteListCommand::class,
+        \Illuminate\Foundation\Console\JobMakeCommand::class,
         \Illuminate\Foundation\Console\ViewCacheCommand::class,
         \Illuminate\Foundation\Console\ViewClearCommand::class,
         \Illuminate\Routing\Console\ControllerMakeCommand::class,
@@ -43,6 +47,8 @@ class Kernel extends FoundationConsoleKernel
         \Roots\Acorn\Console\Commands\RouteCacheCommand::class,
         \Roots\Acorn\Console\Commands\SummaryCommand::class,
         \Roots\Acorn\Console\Commands\VendorPublishCommand::class,
+        \Illuminate\Database\Console\TableCommand::class,
+        \Illuminate\Queue\Console\TableCommand::class,
     ];
 
     /**

--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -5,8 +5,6 @@ namespace Roots\Acorn\Console;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Console\Kernel as FoundationConsoleKernel;
-use Illuminate\Queue\Console\WorkCommand;
-use Illuminate\Queue\Worker;
 
 class Kernel extends FoundationConsoleKernel
 {

--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -14,24 +14,26 @@ class Kernel extends FoundationConsoleKernel
      * @var array
      */
     protected $commands = [
-        \Illuminate\Queue\Console\WorkCommand::class,
         \Illuminate\Cache\Console\ClearCommand::class,
         \Illuminate\Cache\Console\ForgetCommand::class,
         \Illuminate\Database\Console\DbCommand::class,
         \Illuminate\Database\Console\Seeds\SeedCommand::class,
+        \Illuminate\Database\Console\TableCommand::class,
         \Illuminate\Database\Console\WipeCommand::class,
         \Illuminate\Foundation\Console\ClearCompiledCommand::class,
         \Illuminate\Foundation\Console\ComponentMakeCommand::class,
         \Illuminate\Foundation\Console\ConfigClearCommand::class,
         \Illuminate\Foundation\Console\ConsoleMakeCommand::class,
         \Illuminate\Foundation\Console\EnvironmentCommand::class,
+        \Illuminate\Foundation\Console\JobMakeCommand::class,
         \Illuminate\Foundation\Console\PackageDiscoverCommand::class,
         \Illuminate\Foundation\Console\ProviderMakeCommand::class,
         \Illuminate\Foundation\Console\RouteClearCommand::class,
         \Illuminate\Foundation\Console\RouteListCommand::class,
-        \Illuminate\Foundation\Console\JobMakeCommand::class,
         \Illuminate\Foundation\Console\ViewCacheCommand::class,
         \Illuminate\Foundation\Console\ViewClearCommand::class,
+        \Illuminate\Queue\Console\TableCommand::class,
+        \Illuminate\Queue\Console\WorkCommand::class,
         \Illuminate\Routing\Console\ControllerMakeCommand::class,
         \Illuminate\Routing\Console\MiddlewareMakeCommand::class,
         \Roots\Acorn\Console\Commands\AboutCommand::class,
@@ -45,8 +47,6 @@ class Kernel extends FoundationConsoleKernel
         \Roots\Acorn\Console\Commands\RouteCacheCommand::class,
         \Roots\Acorn\Console\Commands\SummaryCommand::class,
         \Roots\Acorn\Console\Commands\VendorPublishCommand::class,
-        \Illuminate\Database\Console\TableCommand::class,
-        \Illuminate\Queue\Console\TableCommand::class,
     ];
 
     /**

--- a/src/Roots/Acorn/DefaultProviders.php
+++ b/src/Roots/Acorn/DefaultProviders.php
@@ -2,6 +2,7 @@
 
 namespace Roots\Acorn;
 
+use Illuminate\Queue\QueueServiceProvider;
 use Illuminate\Support\Collection;
 use Illuminate\Support\DefaultProviders as DefaultProvidersBase;
 
@@ -17,8 +18,8 @@ class DefaultProviders extends DefaultProvidersBase
         \Roots\Acorn\Assets\AssetsServiceProvider::class,
         \Roots\Acorn\Filesystem\FilesystemServiceProvider::class,
         \Roots\Acorn\Providers\AcornServiceProvider::class,
+        \Roots\Acorn\Providers\QueueServiceProvider::class,
         \Roots\Acorn\View\ViewServiceProvider::class,
-        \Illuminate\Queue\QueueServiceProvider::class,
     ];
 
     /**

--- a/src/Roots/Acorn/DefaultProviders.php
+++ b/src/Roots/Acorn/DefaultProviders.php
@@ -18,6 +18,7 @@ class DefaultProviders extends DefaultProvidersBase
         \Roots\Acorn\Filesystem\FilesystemServiceProvider::class,
         \Roots\Acorn\Providers\AcornServiceProvider::class,
         \Roots\Acorn\View\ViewServiceProvider::class,
+        \Illuminate\Queue\QueueServiceProvider::class,
     ];
 
     /**

--- a/src/Roots/Acorn/DefaultProviders.php
+++ b/src/Roots/Acorn/DefaultProviders.php
@@ -2,7 +2,6 @@
 
 namespace Roots\Acorn;
 
-use Illuminate\Queue\QueueServiceProvider;
 use Illuminate\Support\Collection;
 use Illuminate\Support\DefaultProviders as DefaultProvidersBase;
 

--- a/src/Roots/Acorn/Providers/QueueServiceProvider.php
+++ b/src/Roots/Acorn/Providers/QueueServiceProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Roots\Acorn\Providers;
+
+use Illuminate\Queue\Worker;
+use Illuminate\Support\ServiceProvider;
+use Roots\Acorn\Application;
+
+class QueueServiceProvider extends ServiceProvider {
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->alias('queue.worker', Worker::class);
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+       //
+    }
+}

--- a/src/Roots/Acorn/Providers/QueueServiceProvider.php
+++ b/src/Roots/Acorn/Providers/QueueServiceProvider.php
@@ -4,9 +4,9 @@ namespace Roots\Acorn\Providers;
 
 use Illuminate\Queue\Worker;
 use Illuminate\Support\ServiceProvider;
-use Roots\Acorn\Application;
 
-class QueueServiceProvider extends ServiceProvider {
+class QueueServiceProvider extends ServiceProvider
+{
     /**
      * Register services.
      *
@@ -24,6 +24,6 @@ class QueueServiceProvider extends ServiceProvider {
      */
     public function boot()
     {
-       //
+        //
     }
 }


### PR DESCRIPTION
This PR adds support for Laravel Queue.

**How it works:**

- Set queue driver to "database" in **config/queue.php**.
- Create the appropriate migrations with `wp acorn queue:table` and then run the migrations with `wp acorn migrate`.
- Create a dummy Job with `wp acorn make:job TestJob`.
- Dispatch the job from somewhere with `TestJob::dispatch()`.
- Run a queue worker with `wp acorn queue:work`.
- Boom, you have a Laravel worker 🥳