### PR TITLE
Force index.php as fallback template when using block themes

### DIFF
--- a/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
+++ b/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
@@ -35,6 +35,12 @@ trait FiltersTemplates
             $templates = array_diff($templates, $pages);
         }
 
+        if (($index = array_search('index.php', $files)) !== false) {
+            unset($files[$index]);
+
+            $templates[] = 'index.php';
+        }
+
         return [...$pages, ...$files, ...$templates];
     }
 

--- a/src/_ide-helpers.php
+++ b/src/_ide-helpers.php
@@ -9,7 +9,5 @@ namespace Illuminate\View {
      *
      * @codeCoverageIgnore
      */
-    class View
-    {
-    }
+    class View {}
 }


### PR DESCRIPTION
Currently the index.html template will take precedence over any views that have names that should be higher in the template hierarchy. This is because currently, we only stack the files on top of the blade templates when in reality they should be grouped by template names.

I've only noticed this as an issue when trying to use `home.blade.php` as a template for the posts lists but it gets overridden by `index.html` even though that should be a fallback. Moving `index.php` to the end of the list when it exists should ensure that it is only used as a fallback and doesn't take precedence over custom view templates.

This is what the template hierarchy looks like right now

![image](https://github.com/roots/acorn/assets/4543338/f932ea9a-3fa3-42dc-9dc5-47e4e9eec2d4)

And this is what it should look like

![image](https://github.com/roots/acorn/assets/4543338/8bf24621-aa5e-4e9c-9777-136b57a3ce53)
