### PR TITLE
Ensure WordPress template hierarchy is intact for hybrid themes

### DIFF
--- a/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
+++ b/src/Roots/Acorn/Sage/Concerns/FiltersTemplates.php
@@ -2,6 +2,8 @@
 
 namespace Roots\Acorn\Sage\Concerns;
 
+use Illuminate\Support\Str;
+
 trait FiltersTemplates
 {
     /**
@@ -35,13 +37,12 @@ trait FiltersTemplates
             $templates = array_diff($templates, $pages);
         }
 
-        if (($index = array_search('index.php', $files)) !== false) {
-            unset($files[$index]);
-
-            $templates[] = 'index.php';
-        }
-
-        return [...$pages, ...$files, ...$templates];
+        return collect([...$pages, ...$files, ...$templates])
+            ->groupBy(function ($item) {
+                return Str::of($item)->afterLast('/')->before('.');
+            })
+            ->flatten()
+            ->toArray();
     }
 
     /**


### PR DESCRIPTION
While working on a theme with the changes from #382 in place, I realized the issue was greater than just where the `index.php` file is placed in the hierarchy. Currently FSE templates are intentionally prioritized over blade templates, but we lose the WP Template hierarchy.

If we take a look at a Product CPT, this would be the template hierarchy that is currently in place.

![image](https://github.com/user-attachments/assets/fc1dd1bb-9108-45f0-8de4-6f9bc2bed5d8)

As you can see, no matter how specific of a blade template file I create, it will never be prioritized over a `single.html` file in the templates directory. For hybrid themes, templates need to first be grouped by the file slugs with the FSE templates prioritized within those groupings.

This would be the result

![image](https://github.com/user-attachments/assets/fc24f3e8-7338-4725-91ab-c9a5cb075eb6)
