### PR TITLE
Correctly split headers without leading whitespace

### DIFF
--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -143,7 +143,10 @@ trait Bootable
     {
         Route::any('{any?}', fn () => tap(response(''), function (Response $response) {
             foreach (headers_list() as $header) {
-                [$header, $value] = explode(': ', $header, 2);
+                [$header, $value] = explode(':', $header, 2);
+                // HTTP/1.1 Header specification: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2
+                // remove the optional leading whitespace
+                $value = ltrim($value);
 
                 if (! headers_sent()) {
                     header_remove($header);


### PR DESCRIPTION
Fixes #401.

According to https://datatracker.ietf.org/doc/html/rfc7230#section-3.2 headers may contain optional leading whitespace before the value. The previous implementation threw an error if there was no whitespace.