### PR TITLE
🩹 Trim one optional leading space from headers

### DIFF
--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -143,7 +143,7 @@ trait Bootable
     {
         Route::any('{any?}', fn () => tap(response(''), function (Response $response) {
             foreach (headers_list() as $header) {
-                [$header, $value] = explode(':', $header, 2);
+                [$header, $value] = preg_split("/:\s{0,1}/", $header, 2);
 
                 if (! headers_sent()) {
                     header_remove($header);


### PR DESCRIPTION
In my last PR #402 @QWp6t removed the `ltrim`. This leads to one added leading space to every header value. See https://github.com/roots/acorn/issues/404#issuecomment-2391024852

This PR can handle the case `X-Header:Value` which #402 already fixed without adding or removing leading whitespace in other cases.

Examples:
```
'X-Header:Value' => ['X-Header', 'Value']
'X-Header: Value' => ['X-Header', 'Value']
'X-Header:  Value' => ['X-Header', ' Value']
'X-Header:   Value' => ['X-Header', '  Value']
```