### PR TITLE
🚑 Fix responses always returning `200` on WordPress routes (Fixes #411)

### DIFF
--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -180,11 +180,12 @@ trait Bootable
         $path = Str::finish($request->getBaseUrl(), $request->getPathInfo());
 
         $except = collect([
-            rest_url(),
             admin_url(),
             wp_login_url(),
             wp_registration_url(),
         ])->map(fn ($url) => parse_url($url, PHP_URL_PATH))->unique()->filter();
+
+        $api = parse_url(rest_url(), PHP_URL_PATH);
 
         if (
             Str::startsWith($path, $except->all()) ||
@@ -211,7 +212,9 @@ trait Bootable
             return;
         }
 
-        $middleware = $this->config->get('router.wordpress.web', 'web');
+        $middleware = Str::startsWith($path, $api)
+            ? $this->config->get('router.wordpress.api', 'api')
+            : $this->config->get('router.wordpress.web', 'web');
 
         $route->middleware($middleware);
 

--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -180,23 +180,15 @@ trait Bootable
         $path = Str::finish($request->getBaseUrl(), $request->getPathInfo());
 
         $except = collect([
+            rest_url(),
             admin_url(),
             wp_login_url(),
             wp_registration_url(),
         ])->map(fn ($url) => parse_url($url, PHP_URL_PATH))->unique()->filter();
 
-        $api = parse_url(rest_url(), PHP_URL_PATH);
-
         if (
             Str::startsWith($path, $except->all()) ||
             Str::endsWith($path, '.php')
-        ) {
-            return;
-        }
-
-        if (
-            $isApi = Str::startsWith($path, $api) &&
-            redirect_canonical(null, false)
         ) {
             return;
         }
@@ -215,9 +207,11 @@ trait Bootable
             return;
         }
 
-        $config = $this->config->get('router.wordpress', ['web' => 'web', 'api' => 'api']);
+        if (redirect_canonical(null, false)) {
+            return;
+        }
 
-        $route->middleware($isApi ? $config['api'] : $config['web']);
+        $route->middleware('web');
 
         ob_start();
 

--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -211,7 +211,9 @@ trait Bootable
             return;
         }
 
-        $route->middleware('web');
+        $middleware = $this->config->get('router.wordpress.web', 'web');
+
+        $route->middleware($middleware);
 
         ob_start();
 

--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -156,6 +156,8 @@ trait Bootable
                 $response->header('X-Powered-By', $this->version());
             }
 
+            $response->setStatusCode(http_response_code());
+
             $content = '';
 
             $levels = ob_get_level();


### PR DESCRIPTION
This will need back-ported to v4 for those using the experimental flag.