### PR TITLE
🩹 Do not set PHP timezone when bootstrapping configuration

### DIFF
--- a/config-stubs/app.php
+++ b/config-stubs/app.php
@@ -65,7 +65,7 @@ return [
     |
     */
 
-    'timezone' => get_option('timezone_string') ?: env('APP_TIMEZONE', 'UTC'),
+    'timezone' => env('APP_TIMEZONE', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -72,7 +72,7 @@ return [
     |
     */
 
-    'timezone' => get_option('timezone_string') ?: env('APP_TIMEZONE', 'UTC'),
+    'timezone' => env('APP_TIMEZONE', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Roots/Acorn/Bootstrap/LoadConfiguration.php
+++ b/src/Roots/Acorn/Bootstrap/LoadConfiguration.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Roots\Acorn\Bootstrap;
+
+use Illuminate\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Bootstrap\LoadConfiguration as FoundationLoadConfiguration;
+
+class LoadConfiguration extends FoundationLoadConfiguration
+{
+    /**
+     * Bootstrap the given application.
+     *
+     * @return void
+     */
+    public function bootstrap(Application $app)
+    {
+        $items = [];
+
+        // First we will see if we have a cache configuration file. If we do, we'll load
+        // the configuration items from that file so that it is very quick. Otherwise
+        // we will need to spin through every configuration file and load them all.
+        if (file_exists($cached = $app->getCachedConfigPath())) {
+            $items = require $cached;
+
+            $app->instance('config_loaded_from_cache', $loadedFromCache = true);
+        }
+
+        // Next we will spin through all of the configuration files in the configuration
+        // directory and load each one into the repository. This will make all of the
+        // options available to the developer for use in various parts of this app.
+        $app->instance('config', $config = new Repository($items));
+
+        if (! isset($loadedFromCache)) {
+            $this->loadConfigurationFiles($app, $config);
+        }
+
+        // Finally, we will set the application's environment based on the configuration
+        // values that were loaded. We will pass a callback which will be used to get
+        // the environment in a web context where an "--env" switch is not present.
+        $app->detectEnvironment(fn () => $config->get('app.env', 'production'));
+    }
+}

--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -57,7 +57,7 @@ class Kernel extends FoundationConsoleKernel
      */
     protected $bootstrappers = [
         \Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables::class,
-        \Illuminate\Foundation\Bootstrap\LoadConfiguration::class,
+        \Roots\Acorn\Bootstrap\LoadConfiguration::class,
         \Roots\Acorn\Bootstrap\HandleExceptions::class,
         \Roots\Acorn\Bootstrap\RegisterFacades::class,
         \Illuminate\Foundation\Bootstrap\SetRequestForConsole::class,

--- a/src/Roots/Acorn/Http/Kernel.php
+++ b/src/Roots/Acorn/Http/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends HttpKernel
      */
     protected $bootstrappers = [
         \Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables::class,
-        \Illuminate\Foundation\Bootstrap\LoadConfiguration::class,
+        \Roots\Acorn\Bootstrap\LoadConfiguration::class,
         \Roots\Acorn\Bootstrap\HandleExceptions::class,
         \Roots\Acorn\Bootstrap\RegisterFacades::class,
         \Illuminate\Foundation\Bootstrap\RegisterProviders::class,


### PR DESCRIPTION
We don't want Laravel setting PHP's timezone when bootstrapping configuration.

See https://make.wordpress.org/core/2019/09/23/date-time-improvements-wp-5-3/