### PR TITLE
🧑‍💻 Handle the response with the kernel before shutdown

### DIFF
--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -223,22 +223,17 @@ trait Bootable
         ob_start();
 
         remove_action('shutdown', 'wp_ob_end_flush_all', 1);
-        add_action('shutdown', fn () => $this->handleRequest($request), 100);
-    }
 
-    /**
-     * Handle the request.
-     */
-    public function handleRequest(\Illuminate\Http\Request $request): void
-    {
         $kernel = $this->make(HttpKernelContract::class);
 
         $response = $kernel->handle($request);
 
-        $response->send();
+        add_action('shutdown', function () use ($kernel, $request, $response) {
+            $response->send();
 
-        $kernel->terminate($request, $response);
+            $kernel->terminate($request, $response);
 
-        exit((int) $response->isServerError());
+            exit((int) $response->isServerError());
+        }, 100);
     }
 }


### PR DESCRIPTION
Right now the response when Acorn is configured to handle a WordPress route is handled too late in the request for middleware to do things such as add shared data to the view factory (e.g. the session error bag). This fixes it but might need tested more.