### PR TITLE
🩹 Look for Vite manifest

### DIFF
--- a/src/Roots/Acorn/Assets/Manager.php
+++ b/src/Roots/Acorn/Assets/Manager.php
@@ -91,6 +91,12 @@ class Manager
 
         $path = $config['path'];
         $url = $config['url'];
+
+        $viteManifest = $path . '/build/manifest.json';
+        if (file_exists($viteManifest)) {
+            return new Manifest($path, $url, [], ['vite' => ['js' => [], 'css' => []]]);
+        }
+
         $assets = isset($config['assets']) ? $this->getJsonManifest($config['assets']) : [];
         $bundles = isset($config['bundles']) ? $this->getJsonManifest($config['bundles']) : [];
 

--- a/src/Roots/Acorn/Assets/Manager.php
+++ b/src/Roots/Acorn/Assets/Manager.php
@@ -92,7 +92,7 @@ class Manager
         $path = $config['path'];
         $url = $config['url'];
 
-        $viteManifest = $path . '/build/manifest.json';
+        $viteManifest = $path.'/build/manifest.json';
         if (file_exists($viteManifest)) {
             return new Manifest($path, $url, [], ['vite' => ['js' => [], 'css' => []]]);
         }

--- a/src/Roots/Acorn/Assets/Manager.php
+++ b/src/Roots/Acorn/Assets/Manager.php
@@ -7,6 +7,7 @@ use Roots\Acorn\Assets\Contracts\Manifest as ManifestContract;
 use Roots\Acorn\Assets\Exceptions\ManifestNotFoundException;
 use Roots\Acorn\Assets\Middleware\LaravelMixMiddleware;
 use Roots\Acorn\Assets\Middleware\RootsBudMiddleware;
+use Roots\Acorn\Assets\Middleware\ViteMiddleware;
 
 /**
  * Manage assets manifests
@@ -37,6 +38,7 @@ class Manager
      */
     protected $middleware = [
         RootsBudMiddleware::class,
+        ViteMiddleware::class,
         LaravelMixMiddleware::class,
     ];
 
@@ -91,11 +93,6 @@ class Manager
 
         $path = $config['path'];
         $url = $config['url'];
-
-        $viteManifest = $path.'/build/manifest.json';
-        if (file_exists($viteManifest)) {
-            return new Manifest($path, $url, [], ['vite' => ['js' => [], 'css' => []]]);
-        }
 
         $assets = isset($config['assets']) ? $this->getJsonManifest($config['assets']) : [];
         $bundles = isset($config['bundles']) ? $this->getJsonManifest($config['bundles']) : [];

--- a/src/Roots/Acorn/Assets/Manifest.php
+++ b/src/Roots/Acorn/Assets/Manifest.php
@@ -48,6 +48,10 @@ class Manifest implements ManifestContract
         $this->bundles = $bundles;
 
         foreach ($assets as $original => $revved) {
+            if (is_array($revved)) {
+                $revved = $revved['file'];
+            }
+
             $this->assets[$this->normalizeRelativePath($original)] = $this->normalizeRelativePath($revved);
         }
     }

--- a/src/Roots/Acorn/Assets/Middleware/ViteMiddleware.php
+++ b/src/Roots/Acorn/Assets/Middleware/ViteMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Roots\Acorn\Assets\Middleware;
+
+use Illuminate\Support\Facades\Vite;
+
+class ViteMiddleware
+{
+    /**
+     * Handle the manifest config.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    public function handle($config)
+    {
+        if (! Vite::manifestHash()) {
+            return $config;
+        }
+
+        return [
+            'url' => get_theme_file_uri('public/build'),
+            'path' => public_path('build'),
+            'bundles' => public_path('build/manifest.json'),
+            'assets' => public_path('build/manifest.json'),
+        ];
+    }
+}

--- a/src/Roots/Acorn/Assets/Vite.php
+++ b/src/Roots/Acorn/Assets/Vite.php
@@ -17,6 +17,6 @@ class Vite extends FoundationVite
      */
     protected function assetPath($path, $secure = null)
     {
-        return str_replace('/build/build', '/build', asset($path)->uri());
+        return str_replace('/build/build/', '/build/', asset($path)->uri());
     }
 }

--- a/src/Roots/Acorn/Assets/Vite.php
+++ b/src/Roots/Acorn/Assets/Vite.php
@@ -4,6 +4,8 @@ namespace Roots\Acorn\Assets;
 
 use Illuminate\Foundation\Vite as FoundationVite;
 
+use function Roots\asset;
+
 class Vite extends FoundationVite
 {
     /**
@@ -15,6 +17,6 @@ class Vite extends FoundationVite
      */
     protected function assetPath($path, $secure = null)
     {
-        return \Roots\asset($path)->uri();
+        return str_replace('/build/build', '/build', asset($path)->uri());
     }
 }

--- a/tests/Assets/AssetsHelpersTest.php
+++ b/tests/Assets/AssetsHelpersTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Facade;
 use Roots\Acorn\Tests\Test\TestCase;
 
 use function Roots\asset;
@@ -8,8 +9,13 @@ use function Spatie\Snapshots\assertMatchesSnapshot;
 
 uses(TestCase::class);
 
+beforeEach(function () {
+    Facade::setFacadeApplication(new \Roots\Acorn\Application);
+});
+
 it('asset() can access the default manifest', function () {
     $app = new \Roots\Acorn\Application;
+
     $app->singleton('config', fn () => new \Illuminate\Config\Repository([
         'assets' => [
             'default' => 'app',
@@ -29,6 +35,7 @@ it('asset() can access the default manifest', function () {
             ],
         ],
     ]));
+
     $app->register(\Roots\Acorn\Assets\AssetsServiceProvider::class);
 
     assertMatchesSnapshot(asset('app.js')->uri());
@@ -36,6 +43,7 @@ it('asset() can access the default manifest', function () {
 
 it('asset() can access a specified manifest', function () {
     $app = new \Roots\Acorn\Application;
+
     $app->singleton('config', fn () => new \Illuminate\Config\Repository([
         'assets' => [
             'default' => 'app',
@@ -55,6 +63,7 @@ it('asset() can access a specified manifest', function () {
             ],
         ],
     ]));
+
     $app->register(\Roots\Acorn\Assets\AssetsServiceProvider::class);
 
     assertMatchesSnapshot(asset('editor.js', 'editor')->uri());
@@ -81,6 +90,7 @@ it('bundle() can access the default manifest', function () {
             ],
         ],
     ]));
+
     $app->register(\Roots\Acorn\Assets\AssetsServiceProvider::class);
 
     assertMatchesSnapshot(bundle('app')->js()->toJson());
@@ -88,6 +98,7 @@ it('bundle() can access the default manifest', function () {
 
 it('bundle() can access a specified manifest', function () {
     $app = new \Roots\Acorn\Application;
+
     $app->singleton('config', fn () => new \Illuminate\Config\Repository([
         'assets' => [
             'default' => 'app',
@@ -107,6 +118,7 @@ it('bundle() can access a specified manifest', function () {
             ],
         ],
     ]));
+
     $app->register(\Roots\Acorn\Assets\AssetsServiceProvider::class);
 
     assertMatchesSnapshot(bundle('editor', 'editor')->js()->toJson());


### PR DESCRIPTION
This PR allows Sage 11 to use Vite [without requiring a `config/assets.php` file](https://github.com/roots/sage/blob/a4827913978c9fae03ca60376bab92305e96282c/config/assets.php). It looks for Vite's manifest file at the default location while keeping the existing asset pipeline working for legacy builds.