### PR TITLE
🩹 Use `DIRECTORY_SEPARATOR` for fallback storage path

### DIFF
--- a/src/Roots/Acorn/Configuration/Concerns/Paths.php
+++ b/src/Roots/Acorn/Configuration/Concerns/Paths.php
@@ -115,7 +115,10 @@ trait Paths
     protected function fallbackStoragePath(): string
     {
         $files = new Filesystem;
-        $path = Str::finish(WP_CONTENT_DIR, '/cache/acorn');
+        $path = Str::of(WP_CONTENT_DIR)
+            ->finish('/cache/acorn')
+            ->replace('/', DIRECTORY_SEPARATOR)
+            ->toString();
 
         foreach ([
             'framework/cache/data',

--- a/src/Roots/Acorn/Configuration/Concerns/Paths.php
+++ b/src/Roots/Acorn/Configuration/Concerns/Paths.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Env;
 use Illuminate\Support\Str;
 use Roots\Acorn\Filesystem\Filesystem;
 
+use function Illuminate\Filesystem\join_paths;
+
 trait Paths
 {
     /**
@@ -55,7 +57,7 @@ trait Paths
             $paths[$path] = $this->normalizeApplicationPath($path);
         }
 
-        $paths['bootstrap'] = $this->normalizeApplicationPath($path, "{$paths['storage']}/framework");
+        $paths['bootstrap'] = $this->normalizeApplicationPath($path, join_paths($paths['storage'], 'framework'));
 
         return $paths;
     }


### PR DESCRIPTION
Possible fix for users experiencing issues on Windows.

Ref: [[1]](https://discourse.roots.io/t/fatal-error-in-sage11-wp-content-cache-acorn-framework-cache-directory-must-be-present-and-writable/29339) [[2]](https://discourse.roots.io/t/incorrect-route-from-packagemanifest-php/29335/7)