### PR TITLE
Refactor support helpers registration logic

### DIFF
--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -131,9 +131,20 @@ class Application extends FoundationApplication
      */
     protected function registerSupportHelpers()
     {
-        $path = InstalledVersions::getInstallPath('illuminate/support');
-
-        require_once "{$path}/helpers.php";
+        $vendorPath = dirname(__DIR__, 5); // Navigate to the vendor directory
+        $supportHelpersPath = "{$vendorPath}/laravel/framework/src/Illuminate/Support/helpers.php";
+        
+        if (file_exists($supportHelpersPath)) {
+            require_once $supportHelpersPath;
+        } else {
+            // Fallback to local Illuminate directory if it exists
+            $localPath = dirname(__DIR__, 2).'/Illuminate/Support/helpers.php';
+            if (file_exists($localPath)) {
+                require_once $localPath;
+            } else {
+                error_log('Unable to locate Illuminate Support helpers.php file');
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Update the Application class to dynamically locate and include the Illuminate/Support/helpers.php file. This change first attempts to locate the file in the vendor directory. If unavailable, it falls back to a local Illuminate directory. Logs an error if the file cannot be found. This approach improves flexibility and robustness in different development environments.

---

## Context

I tried installing Volt for Livewire, was running into error:

```
Uncaught Error: Failed opening required '/Users/eduwass/Sites/acornv5/app/public/wp-content/plugins/acorn-enabler/laravel/framework/src/Illuminate/Support/helpers.php' (include_path='.:/usr/share/php:/www/wp-content/pear')
in /Users/eduwass/Sites/acornv5/app/public/wp-content/plugins/acorn-enabler/vendor/roots/acorn/src/Roots/Acorn/Application.php on line 134

Call stack:

Roots\Acorn\Application::registerSupportHelpers()
wp-content/plugins/acorn-enabler/vendor/roots/acorn/src/Roots/Acorn/Application.php:62
Roots\Acorn\Application::__construct('/Users/eduwass/Sites...lugins/acorn-enabler')
wp-content/plugins/acorn-enabler/vendor/roots/acorn/src/Roots/Acorn/Application.php:79
Roots\Acorn\Application::configure()
wp-content/plugins/acorn-enabler/acorn-enabler.php:35
{closure}('')
wp-includes/class-wp-hook.php:324
WP_Hook::apply_filters('', array)
wp-includes/class-wp-hook.php:348
WP_Hook::do_action(array)
wp-includes/plugin.php:517
do_action('after_setup_theme')
wp-settings.php:682
require_once('/Users/eduwass/Sites...blic/wp-settings.php')
wp-config.php:106
require_once('/Users/eduwass/Sites...public/wp-config.php')
wp-load.php:50
require_once('/Users/eduwass/Sites...p/public/wp-load.php')
wp-blog-header.php:13
require('/Users/eduwass/Sites...c/wp-blog-header.php')
index.php:17
```

This change fixes that.