### PR TITLE
⏪ use absolute paths in `Application::usePaths()`

### DIFF
--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -173,9 +173,7 @@ class Application extends FoundationApplication
                 throw new Exception("The {$pathType} path type is not supported.");
             }
 
-            $this->{$supportedPaths[$pathType]} = Str::startsWith($path, $this->absoluteCachePathPrefixes)
-                ? $path
-                : $this->basePath($path);
+            $this->{$supportedPaths[$pathType]} = $path;
         }
 
         $this->bindPathsInContainer();

--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -10,7 +10,6 @@ use Illuminate\Foundation\PackageManifest as FoundationPackageManifest;
 use Illuminate\Foundation\ProviderRepository;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 use Roots\Acorn\Application\Concerns\Bootable;
 use Roots\Acorn\Configuration\ApplicationBuilder;
 use Roots\Acorn\Exceptions\SkipProviderException;


### PR DESCRIPTION
This change allows Acorn to work on Windows machines.

If there is a desire to support relative paths, I think we should handle that in [`Configuration/Concerns/Paths`](https://github.com/roots/acorn/blob/main/src/Roots/Acorn/Configuration/Concerns/Paths.php).

For now, I think it's more important to ensure that Acorn works in Windows.