### PR TITLE
🩹 Fix potential exception thrown when using `wp acorn about`

### DIFF
--- a/src/Roots/Acorn/Console/Commands/AboutCommand.php
+++ b/src/Roots/Acorn/Console/Commands/AboutCommand.php
@@ -40,8 +40,8 @@ class AboutCommand extends BaseCommand
             'Debug Mode' => $this->laravel->get('config')->get('app.debug') ? '<fg=yellow;options=bold>ENABLED</>' : 'OFF',
             'Maintenance Mode' => $this->laravel->isDownForMaintenance() ? '<fg=yellow;options=bold>ENABLED</>' : 'OFF',
             'URL' => Str::of(config('app.url'))->replace(['http://', 'https://'], ''),
-            'Plugins' => get_site_transient('update_plugins') && count(get_site_transient('update_plugins')->response) ? '<fg=yellow;options=bold>UPDATES AVAILABLE</>' : '<fg=green;options=bold>UP TO DATE</>',
-            'Themes' => get_site_transient('update_themes') && count(get_site_transient('update_themes')->response) ? '<fg=yellow;options=bold>UPDATES AVAILABLE</>' : '<fg=green;options=bold>UP TO DATE</>',
+            'Plugins' => get_site_transient('update_plugins') && count(get_site_transient('update_plugins')->response ?? []) ? '<fg=yellow;options=bold>UPDATES AVAILABLE</>' : '<fg=green;options=bold>UP TO DATE</>',
+            'Themes' => get_site_transient('update_themes') && count(get_site_transient('update_themes')->response ?? []) ? '<fg=yellow;options=bold>UPDATES AVAILABLE</>' : '<fg=green;options=bold>UP TO DATE</>',
         ]);
 
         collect(static::$customDataResolvers)


### PR DESCRIPTION
The `update_plugins` and `update_themes` transients can exist without response objects.