### PR TITLE
Add support for routes/console.php

### DIFF
--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -77,8 +77,6 @@ trait Bootable
         $kernel->bootstrap();
 
         WP_CLI::add_command('acorn', function ($args, $options) use ($kernel) {
-            $kernel->commands();
-
             $escaped = array_map(fn ($arg) => escapeshellarg($arg), $args);
 
             $command = implode(' ', $escaped);

--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -97,9 +97,8 @@ class Kernel extends FoundationConsoleKernel
     {
         $this->load($this->app->path('Console/Commands'));
 
-        $consoleFile = base_path('routes/console.php');
-        if (file_exists($consoleFile)) {
-            require $consoleFile;
+        if (file_exists($routes = base_path('routes/console.php'))) {
+            require $routes;
         }
     }
 }

--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -86,10 +86,6 @@ class Kernel extends FoundationConsoleKernel
 
         $this->app = $app;
         $this->events = $events;
-
-        $this->app->booted(function () {
-            $this->resolveConsoleSchedule();
-        });
     }
 
     /**

--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -96,5 +96,10 @@ class Kernel extends FoundationConsoleKernel
     public function commands()
     {
         $this->load($this->app->path('Console/Commands'));
+
+        $consoleFile = base_path('routes/console.php');
+        if (file_exists($consoleFile)) {
+            require $consoleFile;
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for `routes/console.php`.

First it removes a duplicate call to `Application::resolveConsoleSchedule()` which causes `Illuminate\Console\Scheduling\Schedule` to be instantiated twice with the first instance not being bound to the container.

Then it removes a duplicate call to `Kernel::commands()` which is already performed by the call to `Kernel::bootstrap()` a few lines above.

Lastly it requires `routes/console.php` if the file exists.