### PR TITLE
🩹 Handle response headers before shutting down

### DIFF
--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -177,6 +177,7 @@ trait Bootable
 
             $response->setContent($content);
         }))
+            ->middleware('wordpress')
             ->where('any', '.*')
             ->name('wordpress');
     }
@@ -225,8 +226,6 @@ trait Bootable
             return;
         }
 
-        $route->middleware('wordpress');
-
         ob_start();
 
         remove_action('shutdown', 'wp_ob_end_flush_all', 1);
@@ -235,8 +234,10 @@ trait Bootable
 
         $response = $kernel->handle($request);
 
+        add_action('send_headers', fn () => $response->sendHeaders(), 100);
+
         add_action('shutdown', function () use ($kernel, $request, $response) {
-            $response->send();
+            $response->sendContent();
 
             $kernel->terminate($request, $response);
 

--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -249,7 +249,7 @@ trait Bootable
         }, 100);
 
         add_action('shutdown', function () use ($kernel, $request, $response) {
-            $response->sendContent();
+            $response->send();
 
             $kernel->terminate($request, $response);
 

--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -234,7 +234,19 @@ trait Bootable
 
         $response = $kernel->handle($request);
 
-        add_action('send_headers', fn () => $response->sendHeaders(), 100);
+        add_action('send_headers', function () use ($response) {
+            foreach ($response->headers->getCookies() as $cookie) {
+                setcookie(
+                    $cookie->getName(),
+                    $cookie->getValue(),
+                    $cookie->getExpiresTime(),
+                    $cookie->getPath(),
+                    $cookie->getDomain(),
+                    $cookie->isSecure(),
+                    $cookie->isHttpOnly()
+                );
+            }
+        }, 100);
 
         add_action('shutdown', function () use ($kernel, $request, $response) {
             $response->sendContent();


### PR DESCRIPTION
Setting cookies when sending the response happens too late in the `shutdown` hook.

It might be worth looking into using `Response::sendContent()` over `Response::send()` and then manually filtering/handling appropriate headers in the `send_headers` hook instead. 

Ideally we'd filter out headers such as `Cache-Control` which causes unexpected behavior as seen in https://github.com/roots/acorn/issues/456.

**EDIT**: I went ahead and implemented the above.