### PR TITLE
🩹 fix: allow 'build' to be part of theme or project name

### DIFF
--- a/src/Roots/Acorn/Assets/Middleware/ViteMiddleware.php
+++ b/src/Roots/Acorn/Assets/Middleware/ViteMiddleware.php
@@ -18,7 +18,7 @@ class ViteMiddleware
             return $config;
         }
 
-        if (str_contains($config['path'], '/build')) {
+        if (str_ends_with($config['path'], '/build')) {
             return $config;
         }
 


### PR DESCRIPTION
If "builder" is in the theme or project name, the vite manifest couldn't be found.