### PR TITLE
🧑‍💻 Set the `SkipProviderException` file and line to the previous exception if available

### DIFF
--- a/src/Roots/Acorn/Exceptions/SkipProviderException.php
+++ b/src/Roots/Acorn/Exceptions/SkipProviderException.php
@@ -17,6 +17,11 @@ class SkipProviderException extends InvalidArgumentException
         parent::__construct($message, $code, $previous);
 
         $this->package = $package;
+
+        if ($previous) {
+            $this->file = $previous->getFile();
+            $this->line = $previous->getLine();
+        }
     }
 
     /**


### PR DESCRIPTION
This improves error handling for packages.