### PR TITLE
🧑‍💻 Add missing `make:model` command

### DIFF
--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -27,6 +27,7 @@ class Kernel extends FoundationConsoleKernel
         \Illuminate\Foundation\Console\ConsoleMakeCommand::class,
         \Illuminate\Foundation\Console\EnvironmentCommand::class,
         \Illuminate\Foundation\Console\JobMakeCommand::class,
+        \Illuminate\Foundation\Console\ModelMakeCommand::class,
         \Illuminate\Foundation\Console\PackageDiscoverCommand::class,
         \Illuminate\Foundation\Console\ProviderMakeCommand::class,
         \Illuminate\Foundation\Console\RouteClearCommand::class,


### PR DESCRIPTION
The `make:model` command is registered in `ArtisanServiceProvider` but wasn't included in the Console Kernel's command list