### PR TITLE
🩹 fix: Clean output buffering up to initial level

### DIFF
--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -123,7 +123,7 @@ trait Bootable
         $kernel->bootstrap($request);
 
         if ($this->app->handlesWordPressRequests()) {
-            $this->registerWordPressRoute();
+            $this->registerWordPressRoute(ob_get_level());
         }
 
         try {
@@ -150,9 +150,9 @@ trait Bootable
     /**
      * Register a default route for WordPress requests.
      */
-    protected function registerWordPressRoute(): void
+    protected function registerWordPressRoute(int $initialObLevel): void
     {
-        Route::any('{any?}', fn () => tap(response(''), function (Response $response) {
+        Route::any('{any?}', fn () => tap(response(''), function (Response $response) use ($initialObLevel) {
             foreach (headers_list() as $header) {
                 [$header, $value] = preg_split("/:\s{0,1}/", $header, 2);
 
@@ -169,7 +169,7 @@ trait Bootable
 
             $levels = ob_get_level();
 
-            for ($i = 0; $i < $levels; $i++) {
+            for ($i = $initialObLevel; $i < $levels; $i++) {
                 $content .= ob_get_clean();
             }
 


### PR DESCRIPTION
This PR should resolve https://github.com/roots/acorn/issues/406

The `registerWordPressRoute` method deletes all levels of output buffering. Caching plugins try to buffer the whole output and write that to a file. Output buffering is started by caching plugins in `{wp-content|app}/advanced-cache.php`, and saved in a callback for that `ob_start()`. As acorn is deleting all buffers from all levels in `Bootable::registerWordPressRoute()`, the output is empty by the time the caching plugin's callback is called.

With this PR, we get the initial ob level,  and delete buffers up until this level.

I have tested this fix with
- WP Rocket
- [Super Page Cache](https://wordpress.org/plugins/wp-cloudflare-page-cache/)
- https://roots.io/acorn/docs/routing/#basic-routing-example
- wordpress routing + livewire
and didn't encounter any issues, but please test thoroughly, as this is quite a critical change.