### PR TITLE
Add --format option to fix --json option with WP-CLI

### DIFF
--- a/src/Roots/Acorn/Console/Commands/AboutCommand.php
+++ b/src/Roots/Acorn/Console/Commands/AboutCommand.php
@@ -10,6 +10,29 @@ use Roots\Acorn\Application;
 
 class AboutCommand extends BaseCommand
 {
+    /**
+     * The console command signature.
+     *
+     * @var string
+     */
+    protected $signature = 'about {--only= : The section to display}
+                {--json : Output the information as JSON}
+                {--format= : The output format (table, json)}';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        if ($this->option('format') === 'json') {
+            $this->input->setOption('json', true);
+        }
+
+        return parent::handle();
+    }
+
     protected function gatherApplicationInformation()
     {
         parent::gatherApplicationInformation();


### PR DESCRIPTION
To fix the current issue, where WP-CLI overrides the `--json` option before executing the about command (#481), I came up with adding a third option `--format` to the command, which conditionally sets the `json` option to true.