### PR TITLE
🔧 Register missing queue console commands

### DIFF
--- a/src/Roots/Acorn/Console/Kernel.php
+++ b/src/Roots/Acorn/Console/Kernel.php
@@ -38,7 +38,6 @@ class Kernel extends FoundationConsoleKernel
         \Illuminate\Queue\Console\FailedTableCommand::class,
         \Illuminate\Queue\Console\FlushFailedCommand::class,
         \Illuminate\Queue\Console\ForgetFailedCommand::class,
-        \Illuminate\Queue\Console\ListenCommand::class,
         \Illuminate\Queue\Console\ListFailedCommand::class,
         \Illuminate\Queue\Console\MonitorCommand::class,
         \Illuminate\Queue\Console\PauseCommand::class,


### PR DESCRIPTION
## Summary
- Registers all missing Laravel queue console commands in the Acorn Console Kernel
- Adds `queue:restart`, `queue:failed`, `queue:retry`, `queue:flush`, `queue:forget`, `queue:monitor`, `queue:pause`, `queue:resume`, `queue:prune-batches`, `queue:prune-failed-jobs`, and `queue:retry-batch`
- Excludes `queue:listen` due to an unresolvable `Illuminate\Queue\Listener` dependency on `$commandPath`

Ref https://discourse.roots.io/t/managing-laravel-queue-workers-in-acorn/30205

Docs updates ready once this is merged and tagged: https://github.com/roots/docs/pull/564