### PR TITLE
🔧 Remove `spatie/laravel-ignition` suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,8 +89,7 @@
     "wp-cli/wp-cli": "^2.10"
   },
   "suggest": {
-    "roots/acorn-prettify": "A collection of modules to apply theme-agnostic front-end modifications (^1.0).",
-    "spatie/laravel-ignition": "A beautiful error page for development (^2.0)."
+    "roots/acorn-prettify": "A collection of modules to apply theme-agnostic front-end modifications (^1.0)."
   },
   "config": {
     "sort-packages": true,


### PR DESCRIPTION
Laravel 12.29 introduced a first-party debug/exception page built directly into the framework, replacing the need for `spatie/laravel-ignition` as a suggested development dependency.

The Laravel skeleton itself had already dropped ignition from its suggested packages, so we're aligning with that here.

References:
- https://laravel-news.com/laravel-12-29-0
- https://github.com/laravel/laravel/commit/5d86ab4b729e23dcdaa3be2c2121c06d0677be61
