### PR TITLE
🐛 Add missing port to wordpress database connection config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -46,6 +46,7 @@ return [
         'wordpress' => [
             'driver' => 'mysql',
             'host' => DB_HOST,
+            'port' => env('DB_PORT', 3306),
             'database' => DB_NAME,
             'username' => DB_USER,
             'password' => DB_PASSWORD,


### PR DESCRIPTION
## Summary
- Adds `'port' => env('DB_PORT', 3306)` to the `wordpress` database connection config
- The `wp acorn db` command was failing with `Empty value for 'port' specified` because the wordpress connection lacked a `port` key, while Laravel's `DbCommand` unconditionally references `$connection['port']` when building CLI arguments
- Other database connections (`mysql`, `mariadb`, `pgsql`, `sqlsrv`) already define a port — this aligns the wordpress connection with them

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)