### PR TITLE
🐛 Force root URL to home_url() for correct route URL generation

### DIFF
--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -122,6 +122,8 @@ trait Bootable
 
         $kernel->bootstrap($request);
 
+        \Illuminate\Support\Facades\URL::forceRootUrl(home_url());
+
         if ($this->app->handlesWordPressRequests()) {
             $this->registerWordPressRoute(ob_get_level());
         }


### PR DESCRIPTION
## Summary
- Forces `URL::forceRootUrl(home_url())` during HTTP boot so `route()` generates correct URLs regardless of the PHP entry point
- Without this, requests handled by `admin-post.php`, `admin-ajax.php`, `wp-cron.php`, etc. cause Symfony's `Request::prepareBaseUrl()` to derive the base path from `SCRIPT_NAME`, resulting in URLs like `http://example.com/wp/wp-admin/admin-post.php/my-route`
- Reproduced and verified the fix with `admin-post.php`, `admin-ajax.php`, and `wp-cron.php`

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)