### PR TITLE
🐛 Defer console boot to wp_loaded for complete WordPress bootstrap

### DIFF
--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -40,7 +40,11 @@ trait Bootable
             if (class_exists('WP_CLI')) {
                 $this->bootWpCli();
             } elseif (defined('USING_ACORN_CLI') && USING_ACORN_CLI) {
-                $this->bootConsole();
+                if (did_action('wp_loaded')) {
+                    $this->bootConsole();
+                } else {
+                    add_action('wp_loaded', fn () => $this->bootConsole(), PHP_INT_MAX);
+                }
             }
 
             return $this;


### PR DESCRIPTION
## Summary
- Defers `bootConsole()` to the `wp_loaded` action when WordPress hasn't fully loaded yet, instead of calling it immediately during `after_setup_theme`
- When the scheduler spawns commands via the acorn binary, the mu-plugin/theme boots Acorn on `after_setup_theme`, which called `bootConsole()` → `exit()` before `wp-settings.php` finished loading. This meant `init` and `wp_loaded` never fired, breaking anything that depends on them (custom post types, taxonomies, rewrite rules, etc.)

## Reproduction

Created a test command that probes the WordPress bootstrap state, scheduled it via `routes/console.php`, and ran `wp acorn schedule:run`.

**Before fix** (scheduler spawning via acorn binary):
```
get_permalink(2): http://radicle.test/sample-page/

did_action(muplugins_loaded): 1
did_action(plugins_loaded): 1
did_action(setup_theme): 1
did_action(after_setup_theme): 1
did_action(init): 0
did_action(wp_loaded): 0
```

**After fix** (scheduler spawning via acorn binary):
```
get_permalink(2): http://radicle.test/sample-page/

did_action(muplugins_loaded): 1
did_action(plugins_loaded): 1
did_action(setup_theme): 1
did_action(after_setup_theme): 1
did_action(init): 1
did_action(wp_loaded): 1
```

Also verified `wp acorn about`, `wp acorn route:list`, `wp acorn config:clear`, and `php vendor/roots/acorn/bin/acorn about` all still work correctly with the fix applied.

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)