### PR TITLE
🐛 Fix package manifest discovery for non-Bedrock project structures

### DIFF
--- a/src/Roots/Acorn/Application.php
+++ b/src/Roots/Acorn/Application.php
@@ -253,14 +253,19 @@ class Application extends FoundationApplication
         $this->singleton(FoundationPackageManifest::class, function () {
             $files = new Filesystem;
 
+            $closestComposer = $files->closest(WP_CONTENT_DIR, 'composer.json');
+            $contentRoot = $closestComposer ? dirname($closestComposer) : null;
+
+            $composerPaths = apply_filters('acorn/composer_paths', array_filter([
+                $this->basePath(),
+                $contentRoot,
+                get_template_directory(),
+                get_stylesheet_directory(),
+            ]));
+
             $composerPaths = collect(get_option('active_plugins'))
                 ->map(fn ($plugin) => WP_PLUGIN_DIR.DIRECTORY_SEPARATOR.dirname($plugin))
-                ->merge([
-                    $this->basePath(),
-                    dirname(WP_CONTENT_DIR, 2),
-                    get_template_directory(),
-                    get_stylesheet_directory(),
-                ])
+                ->merge((array) $composerPaths)
                 ->map(fn ($path) => rtrim($files->normalizePath($path), '/'))
                 ->unique()
                 ->filter(


### PR DESCRIPTION
## Summary

- Replace hardcoded `dirname(WP_CONTENT_DIR, 2)` with a dynamic walk-up from `WP_CONTENT_DIR` to find the nearest `composer.json`, supporting standard WordPress (1 level), Bedrock (2 levels), and custom directory depths
- Add `acorn/composer_paths` filter hook for customizing non-plugin root candidates (base path, content root, theme directories) without subclassing `Application`

The `acorn/composer_paths` filter covers project root candidates only. Active plugin paths remain auto-discovered from WordPress's `active_plugins` option and are merged separately. All paths (including filter-injected ones) pass through normalization, deduplication, and validation (`composer.json` + `vendor/composer/installed.json` must both exist).

Closes #410

## Verification

Reproduced and verified the fix on both Radicle (Bedrock structure) and Sage (theme-based) installs. Full test suite passes on the devcontainer (88 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)