### PR TITLE
🐛 Fix flash session data lost on WordPress page template requests

### DIFF
--- a/src/Roots/Acorn/Configuration/Middleware.php
+++ b/src/Roots/Acorn/Configuration/Middleware.php
@@ -66,7 +66,7 @@ class Middleware extends FoundationMiddleware
             'web' => array_values(array_filter([
                 // \Illuminate\Cookie\Middleware\EncryptCookies::class,
                 \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-                \Illuminate\Session\Middleware\StartSession::class,
+                \Roots\Acorn\Session\Middleware\StartSession::class,
                 \Illuminate\View\Middleware\ShareErrorsFromSession::class,
                 // \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
                 \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/src/Roots/Acorn/Session/Middleware/StartSession.php
+++ b/src/Roots/Acorn/Session/Middleware/StartSession.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Roots\Acorn\Session\Middleware;
+
+use Illuminate\Session\Middleware\StartSession as BaseStartSession;
+
+class StartSession extends BaseStartSession
+{
+    /**
+     * Save the session data to storage.
+     *
+     * For WordPress routes, the session save is deferred until the WordPress
+     * shutdown hook so that flash data remains available during template
+     * rendering (which occurs after the middleware stack completes).
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return void
+     */
+    protected function saveSession($request)
+    {
+        if ($request->route()?->getName() === 'wordpress' && function_exists('add_action')) {
+            add_action('shutdown', fn () => parent::saveSession($request), 0);
+
+            return;
+        }
+
+        parent::saveSession($request);
+    }
+}

--- a/tests/Session/Middleware/StartSessionTest.php
+++ b/tests/Session/Middleware/StartSessionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Route;
+use Illuminate\Session\SessionManager;
+use Illuminate\Session\Store;
+use Roots\Acorn\Session\Middleware\StartSession;
+use Roots\Acorn\Tests\Test\TestCase;
+
+uses(TestCase::class);
+
+function createStartSessionFixtures(): array
+{
+    $store = Mockery::mock(Store::class);
+    $store->shouldReceive('start')->andReturnSelf();
+    $store->shouldReceive('setRequestOnHandler');
+    $store->shouldReceive('getId')->andReturn('test-session-id');
+    $store->shouldReceive('getName')->andReturn('laravel_session');
+    $store->shouldReceive('setPreviousUrl');
+    $store->shouldReceive('setPreviousRoute');
+    $store->shouldReceive('setId');
+
+    $manager = Mockery::mock(SessionManager::class);
+    $manager->shouldReceive('shouldBlock')->andReturn(false);
+    $manager->shouldReceive('driver')->andReturn($store);
+    $manager->shouldReceive('getSessionConfig')->andReturn([
+        'driver' => 'file',
+        'lifetime' => 120,
+        'lottery' => [0, 100],
+        'path' => '/',
+        'domain' => null,
+        'secure' => false,
+        'http_only' => true,
+        'same_site' => 'lax',
+        'partitioned' => false,
+        'expire_on_close' => false,
+    ]);
+
+    return [$manager, $store];
+}
+
+it('should save session immediately for non-wordpress routes', function () {
+    [$manager, $store] = createStartSessionFixtures();
+
+    $store->shouldReceive('save')->once();
+
+    $middleware = new StartSession($manager);
+
+    $request = Request::create('/contact/send', 'POST');
+    $route = new Route('POST', 'contact/send', fn () => 'ok');
+    $route->name('contact.send');
+    $request->setRouteResolver(fn () => $route);
+
+    $middleware->handle($request, fn ($req) => new Response('ok'));
+});
+
+it('should defer session save for wordpress routes until shutdown', function () {
+    [$manager, $store] = createStartSessionFixtures();
+
+    $middleware = new StartSession($manager);
+
+    $request = Request::create('/some-page', 'GET');
+    $route = new Route('GET', '{any?}', fn () => 'ok');
+    $route->name('wordpress');
+    $request->setRouteResolver(fn () => $route);
+
+    // Session save should NOT be called during handle()
+    $store->shouldNotReceive('save');
+
+    $middleware->handle($request, fn ($req) => new Response('ok'));
+
+    // A shutdown hook should have been registered
+    expect($this->filters)->toHaveKey('shutdown');
+
+    // Now allow save and invoke the deferred shutdown callback
+    $store->shouldReceive('save')->once();
+
+    $shutdownCallbacks = $this->filters['shutdown'];
+    foreach ($shutdownCallbacks as $callback) {
+        $callback();
+    }
+});


### PR DESCRIPTION
## Summary

- Flash data set via `session()->flash()` or `redirect()->with()` was lost on WordPress page template requests because Laravel's `StartSession` middleware saved (and aged) the session during `kernel->handle()`, before Blade templates rendered via WordPress's `template_include` hook.
- Introduces a custom `StartSession` middleware that defers `saveSession()` to the WordPress `shutdown` hook (priority 0) for the catch-all `wordpress` route, ensuring flash data remains available during template rendering while preserving standard behavior for non-WordPress Laravel routes.
- Adds unit tests verifying both immediate save on normal routes and deferred save on WordPress routes.

## Test plan

- [x] Reproduced the bug on a Sage install: `session()->put()` survives but `flash()`/`with()` data is missing in Blade templates on WordPress pages
- [x] Verified fix: all three values (`put`, `flash`, `with`) present after redirect
- [x] Verified flash data properly cleared on subsequent request (not persisted forever)
- [x] Verified fix works after `wp acorn optimize`
- [x] 91 tests pass in devcontainer (2 new tests added)
- [x] HTTP 200 on both Radicle and Sage test environments

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)