### PR TITLE
🐛 Isolate cache, session, and queue data on multisite

### DIFF
--- a/src/Roots/Acorn/Providers/AcornServiceProvider.php
+++ b/src/Roots/Acorn/Providers/AcornServiceProvider.php
@@ -186,22 +186,28 @@ class AcornServiceProvider extends ServiceProvider
         });
 
         $events = $this->app->make('events');
+        $switchedJobs = [];
 
-        $events->listen(JobProcessing::class, function (JobProcessing $event) {
+        $events->listen(JobProcessing::class, function (JobProcessing $event) use (&$switchedJobs) {
             $payload = $event->job->payload();
 
             if (isset($payload['blogId'])) {
                 switch_to_blog((int) $payload['blogId']);
+                $switchedJobs[spl_object_id($event->job)] = true;
             }
         });
 
-        $events->listen(JobProcessed::class, function () {
-            restore_current_blog();
-        });
+        $restore = function ($event) use (&$switchedJobs) {
+            $id = spl_object_id($event->job);
 
-        $events->listen(JobExceptionOccurred::class, function () {
-            restore_current_blog();
-        });
+            if (isset($switchedJobs[$id])) {
+                restore_current_blog();
+                unset($switchedJobs[$id]);
+            }
+        };
+
+        $events->listen(JobProcessed::class, $restore);
+        $events->listen(JobExceptionOccurred::class, $restore);
     }
 
     /**

--- a/tests/Providers/MultisiteIsolationTest.php
+++ b/tests/Providers/MultisiteIsolationTest.php
@@ -16,6 +16,7 @@ beforeEach(function () {
     $this->stub('is_multisite', fn () => $this->isMultisite);
     $this->stub('get_current_blog_id', fn () => $this->blogId);
     $this->stub('switch_to_blog', function ($id) {
+        $this->blogIdStack[] = $this->blogId;
         $this->blogId = $id;
         do_action('switch_blog');
     });
@@ -197,6 +198,11 @@ it('should not switch blog for jobs without blogId', function () {
     $container->instance('events', new Dispatcher($container));
     invokeConfigureMultisite($provider);
 
+    // Simulate an outer switch_to_blog(3) that happened before the job
+    switch_to_blog(3);
+    expect($this->blogId)->toBe(3);
+    expect($this->blogIdStack)->toBe([1]);
+
     $mockJob = new class
     {
         public function payload()
@@ -205,6 +211,98 @@ it('should not switch blog for jobs without blogId', function () {
         }
     };
 
+    // Process a legacy job without blogId — should not touch the stack
     $container->make('events')->dispatch(new JobProcessing('sync', $mockJob));
+    expect($this->blogId)->toBe(3);
+    expect($this->blogIdStack)->toBe([1]);
+
+    $container->make('events')->dispatch(new JobProcessed('sync', $mockJob));
+    expect($this->blogId)->toBe(3);
+    expect($this->blogIdStack)->toBe([1]);
+
+    // The outer context should still be restorable
+    restore_current_blog();
+    expect($this->blogId)->toBe(1);
+});
+
+it('should handle nested job processing correctly', function () {
+    $this->isMultisite = true;
+    $this->blogId = 1;
+
+    [$provider, $container] = createProviderWithConfig();
+    $container->instance('events', new Dispatcher($container));
+    invokeConfigureMultisite($provider);
+
+    $outerJob = new class
+    {
+        public function payload()
+        {
+            return ['blogId' => 2];
+        }
+    };
+
+    $innerJob = new class
+    {
+        public function payload()
+        {
+            return ['blogId' => 3];
+        }
+    };
+
+    // Outer job starts — switches to blog 2
+    $container->make('events')->dispatch(new JobProcessing('sync', $outerJob));
+    expect($this->blogId)->toBe(2);
+
+    // Inner job starts — switches to blog 3
+    $container->make('events')->dispatch(new JobProcessing('sync', $innerJob));
+    expect($this->blogId)->toBe(3);
+
+    // Inner job finishes — restores to blog 2
+    $container->make('events')->dispatch(new JobProcessed('sync', $innerJob));
+    expect($this->blogId)->toBe(2);
+
+    // Outer job finishes — restores to blog 1
+    $container->make('events')->dispatch(new JobProcessed('sync', $outerJob));
+    expect($this->blogId)->toBe(1);
+});
+
+it('should not consume outer restore when inner job has no blogId', function () {
+    $this->isMultisite = true;
+    $this->blogId = 1;
+
+    [$provider, $container] = createProviderWithConfig();
+    $container->instance('events', new Dispatcher($container));
+    invokeConfigureMultisite($provider);
+
+    $outerJob = new class
+    {
+        public function payload()
+        {
+            return ['blogId' => 2];
+        }
+    };
+
+    $innerJob = new class
+    {
+        public function payload()
+        {
+            return [];
+        }
+    };
+
+    // Outer job starts — switches to blog 2
+    $container->make('events')->dispatch(new JobProcessing('sync', $outerJob));
+    expect($this->blogId)->toBe(2);
+
+    // Inner job without blogId starts — no switch
+    $container->make('events')->dispatch(new JobProcessing('sync', $innerJob));
+    expect($this->blogId)->toBe(2);
+
+    // Inner job finishes — should NOT restore since it never switched
+    $container->make('events')->dispatch(new JobProcessed('sync', $innerJob));
+    expect($this->blogId)->toBe(2);
+
+    // Outer job finishes — restores to blog 1
+    $container->make('events')->dispatch(new JobProcessed('sync', $outerJob));
     expect($this->blogId)->toBe(1);
 });


### PR DESCRIPTION
## Summary
- On multisite networks, all sites shared the same cache keys, session cookies, and queue job context, causing data collisions and cross-contamination
- Dynamically prefixes `cache.prefix` with `blog_{id}_` and appends `_{id}` to `session.cookie` at runtime in `AcornServiceProvider`
- Injects `blogId` into every queued job payload and switches to the correct blog context before the job is processed, restoring it afterward
- Hooks into `switch_blog` action so config stays correct when blog context changes (e.g. queue workers processing jobs for multiple sites)
- Works with all cache/session drivers (file, Redis, Memcached, database, etc.) and all queue drivers
- Views, logs, and storage paths remain shared as expected for multitenant Laravel applications

## Test plan
- [x] Unit tests for cache prefix and session cookie isolation per blog
- [x] Unit test confirming single-site config is unchanged
- [x] Unit test for config update on blog switch
- [x] Unit test for blogId injection into queue payloads
- [x] Unit test for blog context switching on job processing
- [x] Unit test for blog context restore after job exception
- [x] Unit test for graceful handling of jobs without blogId
- [x] Verified on a local Bedrock multisite (2 subsites) — each site gets unique cache prefix and session cookie
- [x] End-to-end queue test with database driver — dispatched jobs from both sites, processed with `queue:work`, confirmed correct blog context via log output
- [x] All 105 tests passing

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)