### PR TITLE
✨ Add illuminate/pagination dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ We're dedicated to pushing modern WordPress development forward through our open
 
 ## Supported Laravel components
 
+* `illuminate/auth`
 * `illuminate/bus`
 * `illuminate/cache`
 * `illuminate/collections`
@@ -46,6 +47,7 @@ We're dedicated to pushing modern WordPress development forward through our open
 * `illuminate/console`
 * `illuminate/container`
 * `illuminate/contracts`
+* `illuminate/cookie`
 * `illuminate/database`
 * `illuminate/encryption`
 * `illuminate/events`
@@ -54,6 +56,7 @@ We're dedicated to pushing modern WordPress development forward through our open
 * `illuminate/http`
 * `illuminate/log`
 * `illuminate/macroable`
+* `illuminate/pagination`
 * `illuminate/pipeline`
 * `illuminate/queue`
 * `illuminate/routing`
@@ -65,14 +68,10 @@ We're dedicated to pushing modern WordPress development forward through our open
 <details>
   <summary><b>Unsupported components</b></summary>
 
-  * `illuminate/auth`
   * `illuminate/broadcasting`
-  * `illuminate/cookie`
   * `illuminate/mail`
   * `illuminate/notifications`
-  * `illuminate/pagination` ([Available via Log1x/pagi](https://github.com/Log1x/pagi))
   * `illuminate/redis`
-  * `illuminate/testing`
   * `illuminate/translation`
   
 </details>

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
     "illuminate/hashing": "^12.0",
     "illuminate/http": "^12.0",
     "illuminate/log": "^12.0",
+    "illuminate/pagination": "^12.0",
     "illuminate/queue": "^12.0",
     "illuminate/routing": "^12.0",
     "illuminate/support": "^12.0",


### PR DESCRIPTION
## Summary
- Adds `illuminate/pagination` to `composer.json` so Eloquent's `paginate()` works out of the box
- Moves `illuminate/auth` and `illuminate/cookie` from unsupported to supported in README (both are already in `require` and have service providers wired up)
- Removes `illuminate/testing` from unsupported list (already in `require`, dev utility not a runtime component)

Closes #486

## Test plan
- [x] Verify `composer validate` passes
- [x] Confirm `Post::paginate(10)` works without missing class errors — tested on Radicle install, returns `LengthAwarePaginator` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)