### PR TITLE
🐛 Restore original superglobals after Request::capture()

### DIFF
--- a/src/Roots/Acorn/Application/Concerns/Bootable.php
+++ b/src/Roots/Acorn/Application/Concerns/Bootable.php
@@ -123,6 +123,12 @@ trait Bootable
     {
         $kernel = $this->make(HttpKernelContract::class);
 
+        $originalGet = $_GET;
+        $originalPost = $_POST;
+        $originalCookie = $_COOKIE;
+        $originalServer = $_SERVER;
+        $originalRequest = $_REQUEST;
+
         $_GET = stripslashes_deep($_GET);
         $_POST = stripslashes_deep($_POST);
         $_COOKIE = stripslashes_deep($_COOKIE);
@@ -131,7 +137,11 @@ trait Bootable
 
         $request = Request::capture();
 
-        wp_magic_quotes();
+        $_GET = $originalGet;
+        $_POST = $originalPost;
+        $_COOKIE = $originalCookie;
+        $_SERVER = $originalServer;
+        $_REQUEST = $originalRequest;
 
         $this->instance('request', $request);
 


### PR DESCRIPTION
## Summary
- Addresses a potential regression from #508 where re-running
  `wp_magic_quotes()` after `Request::capture()` could produce subtly
  different slashing for payloads with pre-existing escape sequences
  (e.g. JSON strings)
- Instead of strip → capture → re-slash, we now strip → capture → restore
  the exact original superglobals verbatim
- Laravel's `Request` object still gets clean (unslashed) data, preserving
  the #408 fix

Closes #524