### PR TITLE
🐛 Share Vite singleton across all resolution keys

### DIFF
--- a/src/Roots/Acorn/Assets/AssetsServiceProvider.php
+++ b/src/Roots/Acorn/Assets/AssetsServiceProvider.php
@@ -19,7 +19,9 @@ class AssetsServiceProvider extends ServiceProvider
             return new Manager($this->app->make('config')->get('assets'));
         });
 
-        $this->app->singleton('assets.vite', Vite::class);
+        $this->app->singleton(Vite::class);
+
+        $this->app->alias(Vite::class, 'assets.vite');
 
         $this->app->alias(Vite::class, FoundationVite::class);
 


### PR DESCRIPTION
## Summary

`Vite::useCspNonce()` (and any other state set via the `Vite` facade — `useIntegrityKey`, `prefetch`, macros, etc.) was silently dropped before reaching `@vite`-rendered tags.

## Cause

`AssetsServiceProvider` bound only the string key `'assets.vite'` as a singleton, with `Roots\Acorn\Assets\Vite` as its concrete. `Illuminate\Foundation\Vite::class` was aliased to `Vite::class`, but `Vite::class` itself had no binding — so resolving it (or its alias) auto-resolved a fresh instance each time. The `Vite` facade resolves `Foundation\Vite::class`, so the nonce was set on a throwaway instance and `@vite` rendered against a different one.

## Fix

Bind `Roots\Acorn\Assets\Vite` as the singleton, and alias both `'assets.vite'` and `Illuminate\Foundation\Vite::class` to it. All three keys now share one instance.

Fixes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)